### PR TITLE
Add bluetooth animation in ble download mode

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -189,6 +189,12 @@ static uint16_t common_tasks(tmosTaskID task_id, uint16_t events)
 		return events ^ ANI_FLASH;
 	}
 
+	if (events & BLE_NEXT_STEP) {
+		ani_xbm_next_frame(&bluetooth, fb, 10, 0);
+
+		return events ^ BLE_NEXT_STEP;
+	}
+
 	return 0;
 }
 
@@ -256,6 +262,9 @@ void ble_start()
 	tmos_stop_task(common_taskid, ANI_NEXT_STEP);
 	tmos_stop_task(common_taskid, ANI_MARQUE);
 	tmos_stop_task(common_taskid, ANI_FLASH);
+	memset(fb, 0, sizeof(fb));
+
+	tmos_start_reload_task(common_taskid, BLE_NEXT_STEP, 500000 / 625);
 }
 
 void handle_mode_transition()


### PR DESCRIPTION
This is an animation indicating the badge is in download mode.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds a Bluetooth animation to indicate the badge is in download mode. It replaces the framebuffer (fb) with a bitmap (bm) for handling display data and animations, introduces various animation functions, and implements task management for handling different animation steps and Bluetooth download mode. Additionally, it updates the documentation to correct animation mode descriptions and modifies the build system to include new source files.

- **New Features**:
    - Introduced a Bluetooth animation to indicate the badge is in download mode.
- **Enhancements**:
    - Replaced framebuffer (fb) with bitmap (bm) for handling display data and animations.
    - Added various animation functions including scroll, fixed, laser, snowflake, and picture animations.
    - Implemented task management for handling different animation steps and Bluetooth download mode.
- **Build**:
    - Updated Makefile to include new source files for animation and bitmap handling.
- **Documentation**:
    - Updated BadgeBLE.md to correct the animation mode descriptions.

<!-- Generated by sourcery-ai[bot]: end summary -->