### PR TITLE
fix: Framebuffer linked list is misplaced on append

### DIFF
--- a/src/fb.c
+++ b/src/fb.c
@@ -19,7 +19,7 @@ fb_t *fblist_insert(fb_t *at, fb_t *new)
 
 fb_t *fblist_append(fb_t *new) 
 {
-	fblist_insert(new, tail);
+	fblist_insert(tail, new);
 	tail = new;
 	return new;
 }

--- a/src/xbm.c
+++ b/src/xbm.c
@@ -26,6 +26,7 @@ void xbm2fb(xbm_t *xbm, uint16_t *fb, int col, int row)
 	for (int i=0; i < xbm->w; i++) {
 		fb[col+i] = tmpfb[i];
 	}
+	free(tmpfb);
 }
 
 void xbm2fb_dirty(xbm_t *xbm, uint16_t *fb, int col, int row)


### PR DESCRIPTION
Fix #26

Swapped.
