### PR TITLE
fix: crash loop on new chip

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -43,6 +43,9 @@ uint16_t data_flash2newmem(uint8_t **chunk, uint32_t n)
 {
 	data_legacy_t *header = data_get_header(0);
 
+	if (memcmp(header->header, "wang", 5))
+		return 0;
+
 	uint16_t size = bswap16(header->sizes[n]) * LED_ROWS;
 	if (size == 0)
 		return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -79,6 +79,9 @@ void play_splash(xbm_t *xbm, int col, int row)
 
 void load_bmlist()
 {
+	if (data_get_header(0) == 0) // There is no bitmap stored in flash
+		return; // skip
+
 	bm_t *curr_bm = bmlist_current();
 
 	for (int i=0; i<8; i++) {


### PR DESCRIPTION
Resolves: #42 

Changes: skip reading bitmaps on invalid magic header

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix crash loop on new chip by skipping bitmap reading when an invalid magic header is detected.

Bug Fixes:
- Prevent crash loop by skipping bitmap reading when an invalid magic header is detected.

<!-- Generated by sourcery-ai[bot]: end summary -->