### PR TITLE
feat: play all available bitmap slots sequentially

### DIFF
--- a/src/bmlist.c
+++ b/src/bmlist.c
@@ -45,6 +45,11 @@ bm_t *bmlist_gohead()
 	return current;
 }
 
+bm_t *bmlist_head()
+{
+	return head;
+}
+
 bm_t *bmlist_current()
 {
 	return current;
@@ -59,6 +64,10 @@ static void list_del(bm_t *prev, bm_t *next)
 bm_t *bmlist_drop(bm_t *bm)
 {
 	list_del(bm->prev, bm->next);
+	if (bm == head)
+		head = bm->next;
+	if (bm == tail)
+		tail = bm->prev;
 	return bm->next;
 }
 

--- a/src/bmlist.h
+++ b/src/bmlist.h
@@ -36,6 +36,8 @@ bm_t *bmlist_goprev() ;
 bm_t *bmlist_gohead();
 bm_t *bmlist_current();
 
+bm_t *bmlist_head();
+
 void bmlist_init(uint16_t first_bm_width);
 
 #endif /* __BMLIST_H__ */


### PR DESCRIPTION
Resolves #40

Changes:

- Add return step state to animation functions
- Add method to get head node from bitmap list
- Add auto change to next bitmap depend on `is_play_sequentially`

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Implement sequential playback of bitmap slots by modifying animation functions to return step states and adding a method to access the head of the bitmap list. This allows automatic transitions between bitmaps based on the 'is_play_sequentially' flag.

New Features:
- Introduce sequential playback of bitmap slots, allowing automatic transition to the next bitmap when the current one finishes.

Enhancements:
- Modify animation functions to return the step state, enabling better control over animation sequences.
- Add a method to retrieve the head node from the bitmap list, facilitating navigation and management of bitmap sequences.

<!-- Generated by sourcery-ai[bot]: end summary -->