### PR TITLE
feat: Automatically include version numbers

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # fetch tags for versioning
 
       - name: Cache toolchain
         id: cache-toolchain

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,15 @@ OPT = -Os
 
 
 #######################################
+# Get current version
+#######################################
+VERSION = $(shell git describe --tags --dirty)
+VERSION_ABBR = $(shell git describe --abbrev=0 --tags 2>/dev/null || echo "unknown")
+ifeq ($(VERSION_ABBR),unknown)
+	$(warning Unable to determine version from git tags)
+endif
+
+#######################################
 # paths
 #######################################
 # Build path
@@ -127,6 +136,7 @@ ifeq ($(USBC_VERSION), 1)
 CFLAGS += -DUSBC_VERSION=$(USBC_VERSION)
 endif
 
+CFLAGS += -DVERSION='"$(VERSION)"' -DVERSION_ABBR='"$(VERSION_ABBR)"'
 
 # Generate dependency information
 CFLAGS += -MMD -MP

--- a/src/ble/profile/devinfo.c
+++ b/src/ble/profile/devinfo.c
@@ -5,17 +5,25 @@
 static const uint8_t    systemId_val[] = {0, 0, 0, 0, 0, 0, 0, 0};
 static const uint16_t   systemId_UUID = SYSTEM_ID_UUID;
 
-static const uint8_t    modelNumber_val[] = "B1144";
+#ifdef USBC_VERSION
+#define USBC_VER_PREFIX "(C) "
+#define USBC_VER_SUFIX "-C"
+#else
+#define USBC_VER_PREFIX ""
+#define USBC_VER_SUFIX ""
+#endif
+
+static const uint8_t    modelNumber_val[] = "BM1144" USBC_VER_SUFIX;
 static const uint16_t   modelNumber_UUID = MODEL_NUMBER_UUID;
 
 const uint16_t          serialNumber_UUID = SERIAL_NUMBER_UUID;
 static const uint8_t    serialNumber_val[] = "N/A";
 
 const uint16_t          firmwareRev_UUID = FIRMWARE_REV_UUID;
-static const uint8_t    firmwareRev_val[] = "v0.0.1";
+static const uint8_t    firmwareRev_val[] = USBC_VER_PREFIX VERSION;
 
 const uint16_t          hardwareRev_UUID = HARDWARE_REV_UUID;
-static const uint8_t    hardwareRev_val[] = "221028";
+static const uint8_t    hardwareRev_val[] = "20240908";
 
 const uint16_t          softwareRev_UUID = SOFTWARE_REV_UUID;
 static const uint8_t    softwareRev_val[] = "N/A";

--- a/src/main.c
+++ b/src/main.c
@@ -425,7 +425,7 @@ static void disp_charging()
 		if (is_charging()) {
 			disp_bat_stt(blink ? percent : 0, 2, 2);
 			if (ani_xbm_next_frame(&fabm_xbm, fb, 16, 0) == 0) {
-				fb_puts("v0.1", 4, 16, 2); // TODO: get version from git tag
+				fb_puts(VERSION_ABBR, sizeof(VERSION_ABBR), 16, 2);
 				fb_putchar(' ', 40, 2);
 			}
 			blink = !blink;

--- a/src/usb/dev.c
+++ b/src/usb/dev.c
@@ -53,16 +53,30 @@ static uint16_t product_info[] = {
 	'M', 'a', 'g', 'i', 'c'
 };
 
-// TODO: auto update firmware version by CI here
 static uint16_t serial_number[] = {
-	47 * 2 | /* bLength */
+#ifdef USBC_VERSION
+	4 +
+#endif
+	(12 + sizeof(VERSION_ABBR) - 1) * 2 | /* bLength */
 	0x03 << 8, /* bDescriptorType */
 
 	/* bString */
-	'N', 'o', 't', ' ', 'y', 'e', 't', ' ',
-	'i', 'm', 'p', 'l', 'e', 'm', 'e', 'n', 't', 'e', 'd', '\n',
-	'P', 'R', 'E', 'S', 'S', ' ', 'A', 'L', 'T', '+', 'F', '4', ' ',
-	'T', 'O', ' ', 'C', 'O', 'N', 'T', 'I', 'N', 'U', 'E', '.'
+	'B', 'M', '1', '1', '4', '4', 
+#ifdef USBC_VERSION
+	'-', 'C',
+#endif
+	' ',
+	'f', 'w', ':',' ',
+	/* vX.Y */
+	VERSION[0],
+	VERSION[1],
+	VERSION[2],
+	VERSION[3],
+	VERSION[4],
+	VERSION[5],
+	VERSION[6],
+	VERSION[7],
+	VERSION[8]
 };
 
 static void desc_dev(USB_SETUP_REQ *request)


### PR DESCRIPTION
Resolves #44

Changes: 
- Get the version number from git
- Apply version to BLE's Device Info, USB's Serial Number, and charging animation.

## Summary by Sourcery

Automatically embed version numbers from git into various components of the system, including BLE Device Info, USB Serial Number, and charging animation. Enhance the build process to retrieve and define version information from git tags. Update the CI workflow to support versioning by fetching tags.

New Features:
- Automatically embed version numbers from git into the BLE Device Info, USB Serial Number, and charging animation.

Enhancements:
- Update the Makefile to retrieve the current version from git tags and define it for use in the code.

CI:
- Modify the GitHub Actions workflow to fetch tags for versioning by setting fetch-depth to 0.