### PR TITLE
feat: Add a build option for USB-C version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,8 @@ on:
 
 env:
   MRS_TOOLCHAIN: MRS_Toolchain_Linux_x64_V1.91
-  BUILD_DIR: build
+  USBC_BUILD_DIR: usb-c
+  MICROB_BUILD_DIR: micro-b
   BIN_TYPES: '{.bin,.elf}'
 
 jobs:
@@ -32,13 +33,15 @@ jobs:
       - name: Build firmware
         run: |
           export PREFIX=${{ env.MRS_TOOLCHAIN }}/RISC-V_Embedded_GCC/bin/riscv-none-embed-
-          export BUILD_DIR=${{ env.BUILD_DIR }}
-          make -j$(nproc)
+          BUILD_DIR=${{ env.USBC_BUILD_DIR }} USBC_VERSION=1 make -j$(nproc)
+          BUILD_DIR=${{ env.MICROB_BUILD_DIR }} make -j$(nproc)
 
       - uses: actions/upload-artifact@v4
         with:
           name: badgemagic-firmware
-          path: ${{ env.BUILD_DIR }}/badgemagic-*
+          path: |
+            ${{ env.USBC_BUILD_DIR }}/badgemagic-*
+            ${{ env.MICROB_BUILD_DIR }}/badgemagic-*
 
       # Skip upload APK for pull requests & only allow binaries build from master
       - if: ${{ github.event_name != 'pull_request' && github.ref_name == 'master' }}
@@ -47,10 +50,9 @@ jobs:
           git config --global user.name "${{ github.workflow }}"
           git config --global user.email "gh-actions@${{ github.repository_owner }}"
 
-          mv ${{ env.BUILD_DIR }}/badgemagic-*${{ env.BIN_TYPES }} ./
-          
           git checkout --orphan bin
           git reset
-          git add badgemagic-*${{ env.BIN_TYPES }}
+          git add ${{ env.USBC_BUILD_DIR }}/badgemagic-*${{ env.BIN_TYPES }}
+          git add ${{ env.MICROB_BUILD_DIR }}/badgemagic-*${{ env.BIN_TYPES }}
           git commit -am "[Auto] Update firmware binaries from ${{ github.ref_name }} ($(date +%Y-%m-%d.%H:%M:%S))"
           git push --force origin bin

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ TARGET = badgemagic-ch582
 ######################################
 # Uncomment below line to enable debugging
 # DEBUG = 1
+# Uncomment below to build for USB-C version
+# USBC_VERSION = 1
 # optimization for size
 OPT = -Os
 
@@ -118,6 +120,10 @@ CFLAGS = $(MCU) $(C_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections
 
 ifeq ($(DEBUG), 1)
 CFLAGS += -g -gdwarf-2 -DDEBUG=$(DEBUG)
+endif
+
+ifeq ($(USBC_VERSION), 1)
+CFLAGS += -DUSBC_VERSION=$(USBC_VERSION)
 endif
 
 

--- a/src/leddrv.c
+++ b/src/leddrv.c
@@ -88,7 +88,11 @@ static const pinctrl_t led_pins[LED_PINCOUNT] = {
 	PINCTRL(B, 4),  // Q
 	PINCTRL(B, 2),  // R
 	PINCTRL(B, 1),  // S
+#ifdef USBC_VERSION
+	PINCTRL(B, 6), // T
+#else
 	PINCTRL(B, 23), // T
+#endif
 	PINCTRL(B, 21), // U
 	PINCTRL(B, 20), // V
 	PINCTRL(B, 19), // W


### PR DESCRIPTION
Resolve #43.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a build option for the USB-C version of the firmware, updating the Makefile and CI workflow to support separate configurations and build directories for USB-C and Micro-B versions.

New Features:
- Introduce a build option for the USB-C version of the firmware, allowing for separate build directories and configurations.

Enhancements:
- Modify the Makefile to include a conditional compilation flag for the USB-C version, enabling specific code paths for USB-C hardware.

CI:
- Update the GitHub Actions workflow to support building and uploading artifacts for both USB-C and Micro-B versions, with separate build directories.

<!-- Generated by sourcery-ai[bot]: end summary -->