### PR TITLE
Update README.md - Use the exact chip name CH582M

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ MCU type has changed depending on manufacturer batches.
 
 * ARM M0 variant based on [MM32L062PF](http://www.mindmotion.com.cn/en/download.aspx?cid=2564)
 * ARM M0 variant based on [MM32W062](http://www.mindmotion.com.cn/en/download.aspx?cid=2564)
-* RISC-V variant based on [CH582](https://www.wch.cn/products/CH583.html)
+* RISC-V variant based on [CH582M](https://www.wch.cn/products/CH583.html)
 
 See specific pages regarding each version of the hardware below
 


### PR DESCRIPTION
The exact chip number is CH582M on the badges. Because there also exist a CH582F lets make the difference clear that its the M version. https://github.com/ch32-rs/wchisp?tab=readme-ov-file#tested-on

## Summary by Sourcery

Update the README to specify the exact chip name CH582M, ensuring clarity and distinction from other variants such as CH582F.

Documentation:
- Clarify the exact chip name in the README by specifying CH582M instead of CH582 to distinguish it from other variants like CH582F.