### PR TITLE
feat: ble: add battery level characteristic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ src/leddrv.c \
 src/button.c \
 src/bmlist.c \
 src/ble/profile/legacy.c \
+src/ble/profile/batt.c \
 src/ble/profile/devinfo.c \
 src/ble/setup.c \
 src/ble/peripheral.c \
@@ -79,6 +80,7 @@ src/xbm.c \
 src/resource.c \
 src/animation.c \
 src/font.c \
+src/power.c \
 
 
 # ASM sources

--- a/src/ble/profile.h
+++ b/src/ble/profile.h
@@ -3,5 +3,6 @@
 
 int legacy_registerService();
 int devInfo_registerService();
+int batt_registerService();
 
 #endif /* __BLE_UART_SERVICE_H__ */

--- a/src/ble/profile/batt.c
+++ b/src/ble/profile/batt.c
@@ -1,0 +1,52 @@
+#include "utils.h"
+
+#include "../../power.h"
+
+static const uint16_t ServiceUUID = 0x180F;
+static const gattAttrType_t service = {2, (uint8_t *)&ServiceUUID};
+
+static const uint16_t battLv_CharUUID = 0x2A19;
+static uint8 battLv_CharProps = GATT_PROP_READ;
+static uint8 battLv_Val[1];
+
+static gattAttribute_t attr_table[] = {
+	ATTR_DECLAR(primaryServiceUUID, 2, GATT_PERMIT_READ, &service),
+
+	CHAR_DECLAR(&battLv_CharProps),
+	CHAR_VAL_DECLAR(&battLv_CharUUID, 2, GATT_PERMIT_READ, battLv_Val),
+};
+
+static bStatus_t read_handler(uint16_t connHandle, gattAttribute_t *pAttr,
+				uint8_t *p_value, uint16_t *pLen, uint16_t offset,
+				uint16_t maxLen, uint8_t method)
+{
+	uint16_t uuid = BUILD_UINT16(pAttr->type.uuid[0], pAttr->type.uuid[1]);
+
+	if (uuid != battLv_CharUUID) {
+		*pLen = 0;
+		return ATT_ERR_ATTR_NOT_FOUND;
+	}
+
+	*pLen = 1;
+	battLv_Val[0] = batt_raw2percent(batt_raw());
+	tmos_memcpy(p_value, battLv_Val, *pLen);
+
+	return SUCCESS;
+}
+
+static gattServiceCBs_t service_handlers = {
+	read_handler,
+	NULL,
+	NULL
+};
+
+int batt_registerService()
+{
+	uint8 status = SUCCESS;
+
+	status = GATTServApp_RegisterService(attr_table,
+				GATT_NUM_ATTRS(attr_table),
+				GATT_MAX_ENCRYPT_KEY_SIZE,
+				&service_handlers);
+	return (status);
+}

--- a/src/ble/profile/legacy.c
+++ b/src/ble/profile/legacy.c
@@ -65,7 +65,7 @@ static bStatus_t write_handler(uint16 connHandle, gattAttribute_t *pAttr,
 	return ATT_ERR_ATTR_NOT_FOUND;
 }
 
-gattServiceCBs_t service_handlers = {
+static gattServiceCBs_t service_handlers = {
 	NULL,
 	write_handler,
 	NULL

--- a/src/power.c
+++ b/src/power.c
@@ -1,0 +1,78 @@
+#include <CH58xBLE_LIB.h>
+
+#include "power.h"
+#include "button.h"
+
+void poweroff()
+{
+	// Stop wasting energy
+	GPIOA_ModeCfg(GPIO_Pin_All, GPIO_ModeIN_Floating);
+	GPIOB_ModeCfg(GPIO_Pin_All, GPIO_ModeIN_Floating);
+
+	// Configure wake-up
+	GPIOA_ModeCfg(KEY1_PIN, GPIO_ModeIN_PD);
+	GPIOA_ITModeCfg(KEY1_PIN, GPIO_ITMode_RiseEdge);
+	GPIOA_ModeCfg(CHARGE_STT_PIN, GPIO_ModeIN_PU);
+	GPIOA_ITModeCfg(CHARGE_STT_PIN, GPIO_ITMode_FallEdge);
+	PFIC_EnableIRQ(GPIO_A_IRQn);
+	PWR_PeriphWakeUpCfg(ENABLE, RB_SLP_GPIO_WAKE, Long_Delay);
+
+	/* Good bye */
+	LowPower_Shutdown(0);
+}
+
+void power_init()
+{
+	GPIOA_ModeCfg(GPIO_Pin_5, GPIO_ModeIN_Floating);
+	ADC_ExtSingleChSampInit(SampleFreq_3_2, ADC_PGA_0);
+
+	int16_t adc_calib = ADC_DataCalib_Rough();
+	PRINT("RoughCalib_Value = %d \n", adc_calib);
+
+	ADC_ChannelCfg(1);
+}
+
+int batt_raw()
+{
+	int ret = 0;
+
+	PRINT("ADC reading: \n");
+	uint16_t buf[20];
+	for(int i = 0; i < 20; i++) {
+		uint16_t adc = ADC_ExcutSingleConver();
+		ret += adc;
+		PRINT("%d \n", adc);
+	}
+
+	return ret / 20;
+}
+
+int charging_status()
+{
+	GPIOA_ModeCfg(CHARGE_STT_PIN, GPIO_ModeIN_PU);
+	return GPIOA_ReadPortPin(CHARGE_STT_PIN) == 0;
+}
+
+#define ZERO_PERCENT_THRES      (3.3)
+#define _100_PERCENT_THRES      (4.2)
+#define ADC_MAX_VAL             (4096.0) // 12 bit
+#define ADC_MAX_VOLT            (2.1)   // Volt
+#define R1                      (182.0) // kOhm
+#define R2                      (100.0) // kOhm
+#define PERCENT_RANGE           (_100_PERCENT_THRES - ZERO_PERCENT_THRES)
+#define VOLT_DIV(v)             ((v) / (R1 + R2) * R2) // Voltage divider
+#define VOLT_DIV_INV(v)         ((v) / R2 * (R1 + R2)) // .. Inverse
+#define ADC2VOLT(raw)           ((raw) / ADC_MAX_VAL * ADC_MAX_VOLT)
+#define VOLT2ADC(volt)          ((volt) / ADC_MAX_VOLT * ADC_MAX_VAL)
+
+int batt_raw2percent(int r)
+{
+	float vadc = ADC2VOLT(r);
+	float vbat = VOLT_DIV_INV(vadc);
+	float strip = vbat - ZERO_PERCENT_THRES;
+	if (strip < PERCENT_RANGE) {
+		// Negative values meaning the battery is not connected or died
+		return (int)(strip / PERCENT_RANGE * 100.0);
+	}
+	return 100;
+}

--- a/src/power.h
+++ b/src/power.h
@@ -1,11 +1,17 @@
 #ifndef __RESET_H__
 #define __RESET_H__
 
+#define CHARGE_STT_PIN      GPIO_Pin_0 // PA0
+
 static inline void reset_jump()
 {
 	asm volatile("j 0x00");
 }
 
+void power_init();
 void poweroff();
+int batt_raw();
+int charging_status();
+int batt_raw2percent(int r);
 
 #endif /* __RESET_H__ */


### PR DESCRIPTION
App might read battery level from the standard characteristic/service uuid: 0x2A19/0x180F

## Summary by Sourcery

New Features:
- Expose battery level as a readable Bluetooth characteristic using the standard Battery Service (0x180F) and Battery Level Characteristic (0x2A19).