### PR TITLE
Add splash speed and led brightness config

### DIFF
--- a/BadgeBLE.md
+++ b/BadgeBLE.md
@@ -75,9 +75,11 @@ The "mode" bytes are a combination of two 4 bit values. The high nibble describe
 
 - Service-UUID: 0xF055 (128-bit equivalent:
   0000f055-0000-1000-8000-00805f9b34fb)
+- Characteristic: 0xF057 (128-bit equivalent:
+  0000f057-0000-1000-8000-00805f9b34fb)
+  - Write property: to receive controls and configs
 - Characteristic: 0xF056 (128-bit equivalent:
   0000f056-0000-1000-8000-00805f9b34fb)
-  - Write property: to receive controls and configs
   - Notify property: to return error codes
   - Read property: to be implemented
 
@@ -98,6 +100,7 @@ Supported functions/commands:
 - flash_splash_screen
 - save_cfg
 - load_fallback_cfg
+- Miscellaneous configs
 
 The client app should enable notifications for the characteristic to receive the
 returned error code (e.g., by using setCharacteristicNotification() on Android).
@@ -212,4 +215,19 @@ Function/Command code: `0x07`.
 
 Returns:
 
+- Success: `0x00`.
+
+##### Miscellaneous configs
+
+Function/Command code: `0x08`.
+
+Parameters:
+
+- Adjust splash screen speed: `[0x00, speed_ms]`. `speed_ms` (16-bit) is the delay of each frame in milliseconds and must not be lower than 10 ms.
+- Adjust LED brightness: `[0x01, brightness_level]`. `brightness_level` has a value from 0 to 3.
+
+Returns:
+
+- Parameters out of range: `0xff`.
+- `speed_ms` or `brightness_level` is out of allowed range: `0x02`.
 - Success: `0x00`.

--- a/src/config.c
+++ b/src/config.c
@@ -19,7 +19,7 @@ badge_cfg_t badge_cfg;
 /* In case of first time firmware upgrading */
 void cfg_fallback()
 {
-	badge_cfg.ble_always_on = 1;
+	badge_cfg.ble_always_on = 0;
 	memcpy(badge_cfg.ble_devname, "LED Badge Magic\0\0\0\0", 20);
 	/* OEM app testing: */
 	// memcpy(badge_cfg.ble_devname, "LSLED\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 20);

--- a/src/config.h
+++ b/src/config.h
@@ -6,6 +6,8 @@
 #include "xbm.h"
 #include "leddrv.h"
 
+#define SPLASH_MIN_SPEED_T (10) // ms
+
 #define SPLASH_MAX_WIDTH (48) // pixels
 #define SPLASH_MAX_HEIGHT (44) // pixels
 #define SPLASH_MAX_SIZE (ALIGN_1BYTE(SPLASH_MAX_WIDTH) * SPLASH_MAX_HEIGHT)

--- a/src/leddrv.h
+++ b/src/leddrv.h
@@ -6,6 +6,8 @@
 #define LED_COLS 44
 #define LED_ROWS 11
 
+#define BRIGHTNESS_LEVELS   (4)
+
 void led_init();
 void leds_releaseall();
 void led_write2dcol(int dcol, uint16_t col1_val, uint16_t col2_val);

--- a/src/main.c
+++ b/src/main.c
@@ -33,8 +33,6 @@ enum MODES {
 	MODES_COUNT,
 };
 
-#define BRIGHTNESS_LEVELS   (4)
-
 #define ANI_BASE_SPEED_T      (200000) // uS
 #define ANI_MARQUE_SPEED_T    (100000) // uS
 #define ANI_FLASH_SPEED_T     (500000) // uS
@@ -52,12 +50,12 @@ enum MODES {
 static tmosTaskID common_taskid = INVALID_TASK_ID ;
 
 volatile uint16_t fb[LED_COLS] = {0};
-volatile int mode, is_play_sequentially = 1, brightness = 0;
+volatile int mode, is_play_sequentially = 1;
 
 __HIGH_CODE
 static void change_brightness()
 {
-	NEXT_STATE(brightness, 0, BRIGHTNESS_LEVELS);
+	NEXT_STATE(badge_cfg.led_brightness, 0, BRIGHTNESS_LEVELS);
 }
 
 static void mode_setup_download();
@@ -471,7 +469,7 @@ void TMR0_IRQHandler(void)
 				i = 0;
 			led_write2dcol(i >> 2, fb[i >> 1], fb[(i >> 1) + 1]);
 		}
-		else if (state > (brightness&3))
+		else if (state > (badge_cfg.led_brightness&3))
 			leds_releaseall();
 
 		TMR0_ClearITFlag(TMR0_3_IT_CYC_END);


### PR DESCRIPTION
Resolves #52

## Summary by Sourcery

Adds the ability to configure the splash screen speed and LED brightness via BLE. A new `misc` command is added to handle these configurations. The brightness setting is now persisted in the configuration.

New Features:
- Adds the ability to configure the splash screen speed and LED brightness via BLE.

Enhancements:
- The brightness setting is now persisted in the configuration, so it is preserved across reboots.

Documentation:
- Adds documentation for the new miscellaneous config command, including the parameters for adjusting splash screen speed and LED brightness.