### PR TITLE
feat: enable debugging with OpenOCD

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,0 +1,4 @@
+target ext :3333
+monitor init
+monitor reset
+monitor halt

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,14 @@ TARGET = badgemagic-ch582
 # building variables
 ######################################
 # Uncomment below line to enable debugging
-# DEBUG = 1
+DEBUG ?= 1
+
 # Uncomment below to build for USB-C version
 # USBC_VERSION = 1
+
+PREFIX ?= riscv-none-embed-
+OPENOCD ?= ../MRS_Toolchain_Linux_x64_V1.91/OpenOCD/bin/openocd
+
 # optimization for size
 OPT = -Os
 
@@ -92,7 +97,6 @@ CH5xx_ble_firmware_library/Startup/startup_CH583.S
 #######################################
 # binaries
 #######################################
-PREFIX ?= riscv-none-embed-
 
 CC = $(PREFIX)gcc
 AS = $(PREFIX)gcc -x assembler-with-cpp
@@ -199,7 +203,10 @@ $(BUILD_DIR)/%.bin: $(BUILD_DIR)/%.elf
 # Program
 #######################################
 program: $(BUILD_DIR)/$(TARGET).elf
-	sudo wch-openocd -f /usr/share/wch-openocd/openocd/scripts/interface/wch-riscv.cfg -c 'init; halt; program $(BUILD_DIR)/$(TARGET).elf; reset; wlink_reset_resume; exit;'
+	$(OPENOCD) -f interface/wch-riscv.cfg -c 'init; halt; program $(BUILD_DIR)/$(TARGET).elf; reset; wlink_reset_resume; exit;'
+
+debug:
+	$(OPENOCD) -f debug.cfg
 
 isp: $(BUILD_DIR)/$(TARGET).bin
 	wchisp flash $(BUILD_DIR)/$(TARGET).bin

--- a/debug.cfg
+++ b/debug.cfg
@@ -1,0 +1,5 @@
+source [find interface/wch-riscv.cfg]
+
+init
+halt
+reset

--- a/src/leddrv.c
+++ b/src/leddrv.c
@@ -101,8 +101,10 @@ static const pindesc_t led_pins[LED_PINCOUNT] = {
 	PINDESC(A, 11), // G
 	PINDESC(B, 9),  // H
 	PINDESC(B, 8),  // I
-	PINDESC(B, 15), // J
-	PINDESC(B, 14), // K
+
+	PINDESC(B, 17), // J
+	PINDESC(B, 16), // K
+
 	PINDESC(B, 13), // L
 	PINDESC(B, 12), // M
 	PINDESC(B, 5),  // N


### PR DESCRIPTION
This PR set up config for OpenOCD and GDB to work with the firmware that resolves #79. However, it still needs to be documented to explain both the hardware and software setup. I'll keep it as a draft until the document is complete.

## Summary by Sourcery

This PR enables debugging with OpenOCD and GDB. It introduces a debug configuration file and updates the Makefile to include debug and program targets for OpenOCD. It also updates the pin definitions for the LED driver.

New Features:
- Adds a debug configuration file for OpenOCD.

Build:
- Updates the Makefile to include debug and program targets for OpenOCD.
- Adds a default PREFIX variable for the toolchain.
- Adds a default OPENOCD variable for the OpenOCD path.

Tests:
- Adds a .gdbinit file for GDB.