### PR TITLE
chore: added the documentation for flashing firmware from windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Hardware details and information to build an open firmware for Bluetooth LED bad
 
 ## Installation
 
+### Unix
 Install [wchisp](https://github.com/ch32-rs/wchisp?tab=readme-ov-file#installing).
 
 Download prebuilt binaries from [release](https://github.com/fossasia/badgemagic-firmware/releases) or [the latest development builds](https://github.com/fossasia/badgemagic-firmware/tree/bin).
@@ -14,6 +15,14 @@ USB port) while plugging in the USB to enter the bootloader. Then run:
 ```sh
 wchisp flash badgemagic-ch582.bin
 ```
+
+### Windows
+Install and run [wchisp studio](https://www.wch-ic.com/downloads/WCHISPTool_Setup_exe.html)
+connect the badge with usb and enter bootloader.
+
+device will be displayed automatically on the UI.
+
+Select the badgemagic-ch582.bin file and hit download.
 
 Where badgemagic-ch582.bin is the binary downloaded above, the .elf file also
 works.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ wchisp flash badgemagic-ch582.bin
 Install and run [wchisp studio](https://www.wch-ic.com/downloads/WCHISPTool_Setup_exe.html)
 connect the badge with usb and enter bootloader.
 
-device will be displayed automatically on the UI.
+The device will automatically appear in the UI.
 
 Select the badgemagic-ch582.bin file and hit download.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ wchisp flash badgemagic-ch582.bin
 
 ### Windows
 Install and run [wchisp studio](https://www.wch-ic.com/downloads/WCHISPTool_Setup_exe.html)
-connect the badge with usb and enter bootloader.
+Connect the badge via USB and enter bootloader mode.
 
 The device will automatically appear in the UI.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Connect the badge via USB and enter bootloader mode.
 
 The device will automatically appear in the UI.
 
-Select the badgemagic-ch582.bin file and hit download.
+Select the `badgemagic-ch582.bin` file and click 'Download'.
 
 Where badgemagic-ch582.bin is the binary downloaded above, the .elf file also
 works.


### PR DESCRIPTION
Added the documentation for flashing the firmware from windows.

## Summary by Sourcery

Documentation:
- Adds instructions for flashing the firmware from Windows using wchisp studio.