### PR TITLE
Revert latest change pointing to some closed source software

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 Hardware details and information to build an open firmware for Bluetooth LED badges, compatible with [Badge Magic app](https://github.com/fossasia/badgemagic-app)
 
-## Installation
+## Installation (Unix and Windows)
 
-### Unix
 Install [wchisp](https://github.com/ch32-rs/wchisp?tab=readme-ov-file#installing).
 
 Download prebuilt binaries from [release](https://github.com/fossasia/badgemagic-firmware/releases) or [the latest development builds](https://github.com/fossasia/badgemagic-firmware/tree/bin).
@@ -15,15 +14,6 @@ USB port) while plugging in the USB to enter the bootloader. Then run:
 ```sh
 wchisp flash badgemagic-ch582.bin
 ```
-
-### Windows
-Install and run [wchisp studio](https://www.wch-ic.com/downloads/WCHISPTool_Setup_exe.html)
-Connect the badge via USB and enter bootloader mode.
-
-The device will automatically appear in the UI.
-
-Select the `badgemagic-ch582.bin` file and click 'Download'.
-
 Where badgemagic-ch582.bin is the binary downloaded above, the .elf file also
 works.
 


### PR DESCRIPTION
I would like to point to the company name. Its FOSS-ASIA, not closed-source-binary-ASIA ;) So please do not point to some closed source software when there is already the open source software linked that is working also on some closed source platform named Windows (wchisp-v0.3.0-win-x64.zip) . I removed the link to closed source software and added to description, that the open source tool wchisp work on Unix and Windows. https://github.com/ch32-rs/wchisp/releases/tag/v0.3.0

## Summary by Sourcery

Remove instructions for installing and using wchisp studio, a closed-source tool for flashing the badge firmware on Windows. Update the installation instructions to indicate that the open source wchisp tool works on both Unix and Windows.