### PR TITLE
chore: update readme for shorting instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,20 @@ Install [wchisp](https://github.com/ch32-rs/wchisp?tab=readme-ov-file#installing
 
 Download prebuilt binaries from [release](https://github.com/fossasia/badgemagic-firmware/releases) or [the latest development builds](https://github.com/fossasia/badgemagic-firmware/tree/bin).
 
-Make sure the battery is disconnected. Press and hold KEY2 (the button near the
-USB port) while plugging in the USB to enter the bootloader. Then run:
+Make the chip enter bootloader mode (ISP mode) by power cycling the chip while
+the boot pin is pulled down in one of two ways:
+
+- Disconnect the battery, press and hold KEY2 (the button near the USB port)
+  while plugging in the USB to enter the bootloader.
+- Alternatively, connect the USB, press and hold KEY2, then short and release
+  the C3 capacitor.
+
+Then check `dmesg` if the chip has entered the ISP mode with idVendor=4348 and
+idProduct=55e0.
+
+![c3](assets/burn-badge.svg)
+
+Then run:
 
 ```sh
 wchisp flash badgemagic-ch582.bin


### PR DESCRIPTION
How to flash without a soldering iron.

## Summary by Sourcery

Update README to improve flashing instructions without soldering by adding an alternative C3 shorting method, a dmesg verification step, and an illustrative diagram asset.

Documentation:
- Add alternative ISP entry method by shorting the C3 capacitor instead of disconnecting the battery
- Add instructions to verify ISP mode via dmesg output (idVendor=4348, idProduct=55e0)
- Include burn-badge.svg diagram asset to illustrate the shorting procedure