### PR TITLE
feat: enable always on mode

### DIFF
--- a/src/ble/profile/legacy.c
+++ b/src/ble/profile/legacy.c
@@ -17,34 +17,34 @@ static gattAttribute_t attr_table[] = {
 };
 
 static bStatus_t write_handler(uint16 connHandle, gattAttribute_t *pAttr,
-				uint8 *pValue, uint16 len, uint16 offset, uint8 method)
+							   uint8 *pValue, uint16 len, uint16 offset, uint8 method)
 {
-	if(gattPermitAuthorWrite(pAttr->permissions)) {
+	if (gattPermitAuthorWrite(pAttr->permissions))
+	{
 		return ATT_ERR_INSUFFICIENT_AUTHOR;
 	}
 
 	uint16_t uuid = BUILD_UINT16(pAttr->type.uuid[0], pAttr->type.uuid[1]);
-	if(uuid == RxCharUUID) {
+	if (uuid == RxCharUUID)
+	{
 		legacy_ble_rx(pValue, len);
 		return SUCCESS;
 	}
 	return ATT_ERR_ATTR_NOT_FOUND;
 }
 
-
 static gattServiceCBs_t service_handlers = {
 	NULL,
 	write_handler,
-	NULL
-};
+	NULL};
 
 int legacy_registerService()
 {
 	uint8 status = SUCCESS;
 
 	status = GATTServApp_RegisterService(attr_table,
-				GATT_NUM_ATTRS(attr_table),
-				GATT_MAX_ENCRYPT_KEY_SIZE,
-				&service_handlers);
+										 GATT_NUM_ATTRS(attr_table),
+										 GATT_MAX_ENCRYPT_KEY_SIZE,
+										 &service_handlers);
 	return (status);
 }

--- a/src/ble/profile/legacy.c
+++ b/src/ble/profile/legacy.c
@@ -25,13 +25,12 @@ static bStatus_t write_handler(uint16 connHandle, gattAttribute_t *pAttr,
 
 	uint16_t uuid = BUILD_UINT16(pAttr->type.uuid[0], pAttr->type.uuid[1]);
 	if(uuid == RxCharUUID) {
-		if (legacy_ble_rx(pValue, len)) {
-			return ATT_ERR_UNLIKELY;
-		}
+		legacy_ble_rx(pValue, len);
 		return SUCCESS;
 	}
 	return ATT_ERR_ATTR_NOT_FOUND;
 }
+
 
 static gattServiceCBs_t service_handlers = {
 	NULL,

--- a/src/ble/profile/ng.c
+++ b/src/ble/profile/ng.c
@@ -5,6 +5,8 @@
 #include "../../power.h"
 #include "../../ngctrl.h"
 #include "../../debug.h"
+#include "../../config.h"
+#include "../setup.h"
 
 static const uint16_t ServiceUUID = 0xF055;
 static const gattAttrType_t service = {2, (uint8_t *)&ServiceUUID};
@@ -20,141 +22,145 @@ static uint8_t RxCharProps = GATT_PROP_WRITE;
 static gattCharCfg_t TxCCCD[1];
 
 static gattAttribute_t attr_table[] = {
-	ATTR_DECLAR(primaryServiceUUID, 2, GATT_PERMIT_READ, &service),
+    ATTR_DECLAR(primaryServiceUUID, 2, GATT_PERMIT_READ, &service),
 
-	CHAR_DECLAR(&RxCharProps),
-	CHAR_VAL_DECLAR(&RxCharUUID, 2, GATT_PERMIT_WRITE, RxCharVal),
+    CHAR_DECLAR(&RxCharProps),
+    CHAR_VAL_DECLAR(&RxCharUUID, 2, GATT_PERMIT_WRITE, RxCharVal),
 
-	CHAR_DECLAR(&TxCharProps),
-	CHAR_VAL_DECLAR(&TxCharUUID, 2, GATT_PERMIT_READ, TxCharVal),
-	ATTR_DECLAR(clientCharCfgUUID, 2, GATT_PERMIT_READ | GATT_PERMIT_WRITE, TxCCCD),
+    CHAR_DECLAR(&TxCharProps),
+    CHAR_VAL_DECLAR(&TxCharUUID, 2, GATT_PERMIT_READ, TxCharVal),
+    ATTR_DECLAR(clientCharCfgUUID, 2, GATT_PERMIT_READ | GATT_PERMIT_WRITE, TxCCCD),
 };
 
 #define notiAttr attr_table[4]
 
 
 static bStatus_t write_handler(uint16 connHandle, gattAttribute_t *pAttr,
-				uint8 *pValue, uint16 len, uint16 offset, uint8 method)
+                uint8 *pValue, uint16 len, uint16 offset, uint8 method)
 {
-	PRINT("ble: write_handler(): connHandle: %04X\n", connHandle);
+    PRINT("ble: write_handler(): connHandle: %04X\n", connHandle);
 
-	if (!gattPermitWrite(pAttr->permissions)) {
-		return ATT_ERR_WRITE_NOT_PERMITTED;
-	}
-	
-	uint16_t uuid = BUILD_UINT16(pAttr->type.uuid[0], pAttr->type.uuid[1]);
-	if(uuid == GATT_CLIENT_CHAR_CFG_UUID) {
-		bStatus_t ret = GATTServApp_ProcessCCCWriteReq(connHandle, pAttr, pValue, len,
-				offset, GATT_CLIENT_CFG_NOTIFY);
-		PRINT("ble: CCCD changed: %02X\n", TxCCCD->value);
-		return ret;
-	}
+    if (!gattPermitWrite(pAttr->permissions)) {
+        return ATT_ERR_WRITE_NOT_PERMITTED;
+    }
+    
+    uint16_t uuid = BUILD_UINT16(pAttr->type.uuid[0], pAttr->type.uuid[1]);
+    if(uuid == GATT_CLIENT_CHAR_CFG_UUID) {
+        bStatus_t ret = GATTServApp_ProcessCCCWriteReq(connHandle, pAttr, pValue, len,
+                offset, GATT_CLIENT_CFG_NOTIFY);
+        PRINT("ble: CCCD changed: %02X\n", TxCCCD->value);
+        return ret;
+    }
 
-	if (uuid == RxCharUUID) {
-		return ng_parse(pValue, len);
-	}
+    if (uuid == RxCharUUID) {
+        return ng_parse(pValue, len);
+    }
 
-	return ATT_ERR_ATTR_NOT_FOUND;
+    return ATT_ERR_ATTR_NOT_FOUND;
 }
 
 static bStatus_t read_handler(uint16_t connHandle, gattAttribute_t *pAttr,
-				uint8_t *pValue, uint16_t *pLen, uint16_t offset,
-				uint16_t maxLen, uint8_t method)
+                uint8_t *pValue, uint16_t *pLen, uint16_t offset,
+                uint16_t maxLen, uint8_t method)
 {
-	if (!gattPermitRead(pAttr->permissions)) {
-		return ATT_ERR_READ_NOT_PERMITTED;
-	}
+    if (!gattPermitRead(pAttr->permissions)) {
+        return ATT_ERR_READ_NOT_PERMITTED;
+    }
 
-	uint16_t uuid = BUILD_UINT16(pAttr->type.uuid[0], pAttr->type.uuid[1]);
-	if(uuid == GATT_CLIENT_CHAR_CFG_UUID) {
-		*pLen = 2;
-		tmos_memcpy(pValue, pAttr->pValue, *pLen);
-		return SUCCESS;
-	}
+    uint16_t uuid = BUILD_UINT16(pAttr->type.uuid[0], pAttr->type.uuid[1]);
+    if(uuid == GATT_CLIENT_CHAR_CFG_UUID) {
+        *pLen = 2;
+        tmos_memcpy(pValue, pAttr->pValue, *pLen);
+        return SUCCESS;
+    }
 
-	if (uuid == TxCharUUID) {
-		*pLen = MIN(TxLen-offset, maxLen);
-		tmos_memcpy(pValue, &pAttr->pValue[offset], *pLen);
-		return SUCCESS;
-	}
+    if (uuid == TxCharUUID) {
+        *pLen = MIN(TxLen-offset, maxLen);
+        tmos_memcpy(pValue, &pAttr->pValue[offset], *pLen);
+        return SUCCESS;
+    }
 
-	return ATT_ERR_ATTR_NOT_FOUND;
+    return ATT_ERR_ATTR_NOT_FOUND;
 }
 
 static gattServiceCBs_t service_handlers = {
-	read_handler,
-	write_handler,
-	NULL
+    read_handler,
+    write_handler,
+    NULL
 };
 
 static void connStatus_handler(uint16 connHandle, uint8 changeType)
 {
-	if(connHandle == LOOPBACK_CONNHANDLE)
-		return;
+    if(connHandle == LOOPBACK_CONNHANDLE)
+        return;
 
-	// Reset ClientCharConfig if connection has dropped
-	if((changeType == LINKDB_STATUS_UPDATE_REMOVED)
-				|| ((changeType == LINKDB_STATUS_UPDATE_STATEFLAGS)
-				&& (!linkDB_Up(connHandle)))) {
-		GATTServApp_InitCharCfg(connHandle, TxCCCD);
-	}
+    // Reset ClientCharConfig if connection has dropped
+    if((changeType == LINKDB_STATUS_UPDATE_REMOVED)
+                || ((changeType == LINKDB_STATUS_UPDATE_STATEFLAGS)
+                && (!linkDB_Up(connHandle)))) {
+        GATTServApp_InitCharCfg(connHandle, TxCCCD);
+    }
+    if (badge_cfg.ble_always_on) {
+            PRINT("BLE disconnected, restarting advertising due to Always-On\n");
+            ble_enable_advertise();
+    }
 }
 
 int ng_registerService()
 {
-	uint8 status = SUCCESS;
-	GATTServApp_InitCharCfg(INVALID_CONNHANDLE, TxCCCD);
-	linkDB_Register(connStatus_handler);
+    uint8 status = SUCCESS;
+    GATTServApp_InitCharCfg(INVALID_CONNHANDLE, TxCCCD);
+    linkDB_Register(connStatus_handler);
 
-	status = GATTServApp_RegisterService(attr_table,
-				GATT_NUM_ATTRS(attr_table),
-				GATT_MAX_ENCRYPT_KEY_SIZE,
-				&service_handlers);
-	return (status);
+    status = GATTServApp_RegisterService(attr_table,
+                GATT_NUM_ATTRS(attr_table),
+                GATT_MAX_ENCRYPT_KEY_SIZE,
+                &service_handlers);
+    return (status);
 }
 
 static uint8 isNotifyEnabled(uint16 connHandle)
 {
-	uint16_t val = GATTServApp_ReadCharCfg(connHandle, TxCCCD);
-	return val & GATT_CLIENT_CFG_NOTIFY;
+    uint16_t val = GATTServApp_ReadCharCfg(connHandle, TxCCCD);
+    return val & GATT_CLIENT_CFG_NOTIFY;
 }
 /**
  * @brief   Send notify to client. Currently support one client connection
  *          only.
  * 
- * @param	val Value to be sent
- * @param	len length of val. This should not be larger than MTU.
- * @return	bStatus_t
+ * @param   val Value to be sent
+ * @param   len length of val. This should not be larger than MTU.
+ * @return  bStatus_t
  */
 bStatus_t ng_notify(uint8_t *val, uint8_t len)
 {
-	if(!isNotifyEnabled(TxCCCD->connHandle)) {
-		PRINT("ble: ng_notify() notify is not enabled\n");
-		return bleIncorrectMode;
-	}
-	if(len > ATT_GetMTU(TxCCCD->connHandle)) {
-		return bleInvalidRange;
-	}
+    if(!isNotifyEnabled(TxCCCD->connHandle)) {
+        PRINT("ble: ng_notify() notify is not enabled\n");
+        return bleIncorrectMode;
+    }
+    if(len > ATT_GetMTU(TxCCCD->connHandle)) {
+        return bleInvalidRange;
+    }
 
-	attHandleValueNoti_t noti = {
-		.handle = notiAttr.handle,
-		.len = len
-	};
-	noti.pValue = GATT_bm_alloc(TxCCCD->connHandle, ATT_HANDLE_VALUE_NOTI,
-				len, NULL, 0);
-	if (noti.pValue == NULL) {
-		return bleMemAllocError;
-	}
+    attHandleValueNoti_t noti = {
+        .handle = notiAttr.handle,
+        .len = len
+    };
+    noti.pValue = GATT_bm_alloc(TxCCCD->connHandle, ATT_HANDLE_VALUE_NOTI,
+                len, NULL, 0);
+    if (noti.pValue == NULL) {
+        return bleMemAllocError;
+    }
 
-	tmos_memcpy(noti.pValue, val, len);
+    tmos_memcpy(noti.pValue, val, len);
 
-	bStatus_t ret = GATT_Notification(TxCCCD->connHandle, &noti, FALSE);
-	GATT_bm_free((gattMsg_t *)&noti, ATT_HANDLE_VALUE_NOTI);
-	if (ret != SUCCESS) {
-		PRINT("ble: noti sending failed\n");
-		return ret;
-	}
+    bStatus_t ret = GATT_Notification(TxCCCD->connHandle, &noti, FALSE);
+    GATT_bm_free((gattMsg_t *)&noti, ATT_HANDLE_VALUE_NOTI);
+    if (ret != SUCCESS) {
+        PRINT("ble: noti sending failed\n");
+        return ret;
+    }
 
-	PRINT("ble: noti sent\n");
-	return SUCCESS;
+    PRINT("ble: noti sent\n");
+    return SUCCESS;
 }

--- a/src/ble/setup.c
+++ b/src/ble/setup.c
@@ -1,9 +1,13 @@
 #include <memory.h>
 #include <stdlib.h>
-
-#include "setup.h"
-#include "CH58xBLE_LIB.h"
+#include <stdint.h>
+#include <string.h>
 #include "CH58x_common.h"
+
+#include "config.h"
+#include "debug.h"
+#include "legacyctrl.h"
+#include "ngctrl.h"
 
 #ifndef BLE_BUFF_LEN
 // MTU = 64 but clients should request new MTU, otherwise default will be 23
@@ -40,12 +44,6 @@
 static __attribute__((aligned(4), section(".noinit")))
 uint32_t MEM_BUF[BLE_MEMHEAP_SIZE / 4];
 
-if (badge_cfg.ble_always_on) {
-        ble_enable_advertise();
-    } else {
-        ble_disable_advertise();
-    }
-	
 static void lsi_calib(void)
 {
 	Calibration_LSI(Level_128);
@@ -86,4 +84,22 @@ void ble_hardwareInit(void)
 	memcpy(cfg.MacAddr, m, 6);
 
 	BLE_LibInit(&cfg);
+}
+
+void ble_setup(void)
+{
+	ble_hardwareInit();
+	tmos_clockInit();
+	peripheral_init();
+
+	if (badge_cfg.ble_always_on) {
+		ble_enable_advertise();
+	} else {
+		ble_disable_advertise();
+	}
+
+	devInfo_registerService();
+	legacy_registerService();
+	batt_registerService();
+	ng_registerService();
 }

--- a/src/ble/setup.c
+++ b/src/ble/setup.c
@@ -40,6 +40,12 @@
 static __attribute__((aligned(4), section(".noinit")))
 uint32_t MEM_BUF[BLE_MEMHEAP_SIZE / 4];
 
+if (badge_cfg.ble_always_on) {
+        ble_enable_advertise();
+    } else {
+        ble_disable_advertise();
+    }
+	
 static void lsi_calib(void)
 {
 	Calibration_LSI(Level_128);

--- a/src/ble/setup.c
+++ b/src/ble/setup.c
@@ -1,44 +1,52 @@
-#include <memory.h>
-#include <stdlib.h>
-#include <stdint.h>
-#include <string.h>
 #include "CH58x_common.h"
+#include "CH58x_sys.h"
+#include "CH58xBLE_LIB.h"
 
+#include "leddrv.h"
+#include "button.h"
+#include "bmlist.h"
+#include "resource.h"
+#include "animation.h"
+#include "font.h"
+
+#include "power.h"
+#include "data.h"
 #include "config.h"
 #include "debug.h"
+
+#include "ble/setup.h"
+#include "ble/profile.h"
+
+#include "usb/usb.h"
 #include "legacyctrl.h"
-#include "ngctrl.h"
 
 #ifndef BLE_BUFF_LEN
-// MTU = 64 but clients should request new MTU, otherwise default will be 23
-#define BLE_BUFF_LEN (64 + 4)
+#define BLE_BUFF_LEN (64 + 4) // MTU = 64
 #endif
 
 #ifndef BLE_TX_NUM_EVENT
-#define BLE_TX_NUM_EVENT                    1
+#define BLE_TX_NUM_EVENT 1
 #endif
 
 #ifndef BLE_TX_POWER
-#define BLE_TX_POWER                        LL_TX_POWEER_6_DBM
-// #define BLE_TX_POWER                        LL_TX_POWEER_MINUS_16_DBM
+#define BLE_TX_POWER LL_TX_POWEER_6_DBM
+// #define BLE_TX_POWER LL_TX_POWER_MINUS_16_DBM
 #endif
 
 #ifndef BLE_MEMHEAP_SIZE
-#define BLE_MEMHEAP_SIZE                    (1024 * 6)
+#define BLE_MEMHEAP_SIZE (1024 * 6)
 #endif
 
 #ifndef CENTRAL_MAX_CONNECTION
-#define CENTRAL_MAX_CONNECTION              1
+#define CENTRAL_MAX_CONNECTION 1
 #endif
 
 #ifndef BLE_BUFF_NUM
-// The BLE lib automatically stack up Write Long messages in Write handler.
-// A connection will be disconnected if this number is some how not enough.
-#define BLE_BUFF_NUM        (512 / 23)
+#define BLE_BUFF_NUM (512 / 23)
 #endif
 
 #ifndef PERIPHERAL_MAX_CONNECTION
-#define PERIPHERAL_MAX_CONNECTION           1
+#define PERIPHERAL_MAX_CONNECTION 1
 #endif
 
 static __attribute__((aligned(4), section(".noinit")))
@@ -74,9 +82,7 @@ void ble_hardwareInit(void)
 	cfg.TxNumEvent = (uint32_t)BLE_TX_NUM_EVENT;
 	cfg.TxPower = (uint32_t)BLE_TX_POWER;
 	cfg.ConnectNumber = (PERIPHERAL_MAX_CONNECTION & 3) | (CENTRAL_MAX_CONNECTION << 2);
-
 	cfg.SelRTCClock = 1 << 7;
-
 	cfg.rcCB = lsi_calib;
 
 	uint8_t m[6];
@@ -92,9 +98,12 @@ void ble_setup(void)
 	tmos_clockInit();
 	peripheral_init();
 
-	if (badge_cfg.ble_always_on) {
+	if (badge_cfg.ble_always_on)
+	{
 		ble_enable_advertise();
-	} else {
+	}
+	else
+	{
 		ble_disable_advertise();
 	}
 

--- a/src/config.h
+++ b/src/config.h
@@ -8,11 +8,12 @@
 
 #define SPLASH_MIN_SPEED_T (10) // ms
 
-#define SPLASH_MAX_WIDTH (48) // pixels
+#define SPLASH_MAX_WIDTH (48)  // pixels
 #define SPLASH_MAX_HEIGHT (44) // pixels
 #define SPLASH_MAX_SIZE (ALIGN_1BYTE(SPLASH_MAX_WIDTH) * SPLASH_MAX_HEIGHT)
 
-typedef struct {
+typedef struct
+{
 	// Turn on Bluetooth while in Normal mode and disable Downloads mode
 	uint8_t ble_always_on;
 	char ble_devname[20];
@@ -33,7 +34,6 @@ typedef struct {
 } __attribute__((packed)) badge_cfg_t;
 
 extern badge_cfg_t badge_cfg;
-
 void cfg_init();
 int cfg_writeflash(uint16_t flash_offs, badge_cfg_t *cfg);
 int cfg_readflash(uint16_t flash_offs, badge_cfg_t *cfg);

--- a/src/config.h
+++ b/src/config.h
@@ -40,5 +40,6 @@ int cfg_readflash(uint16_t flash_offs, badge_cfg_t *cfg);
 int cfg_writeflash_def(badge_cfg_t *cfg);
 int cfg_readflash_def(badge_cfg_t *cfg);
 void cfg_fallback();
+bool ble_always_on;
 
 #endif /* __CONFIG_H__ */

--- a/src/config.h
+++ b/src/config.h
@@ -2,7 +2,7 @@
 #define __CONFIG_H__
 
 #include <stdint.h>
-
+#include <stdbool.h>
 #include "xbm.h"
 #include "leddrv.h"
 
@@ -40,6 +40,8 @@ int cfg_readflash(uint16_t flash_offs, badge_cfg_t *cfg);
 int cfg_writeflash_def(badge_cfg_t *cfg);
 int cfg_readflash_def(badge_cfg_t *cfg);
 void cfg_fallback();
-bool ble_always_on;
+
+// Declare as extern to avoid multiple definition errors
+extern bool ble_always_on;
 
 #endif /* __CONFIG_H__ */

--- a/src/legacyctrl.c
+++ b/src/legacyctrl.c
@@ -3,103 +3,127 @@
 #include "leddrv.h"
 #include "debug.h"
 #include "legacyctrl.h"
+#include <stdlib.h>
+#include <string.h>
+
+typedef enum {
+    LEGACY_BLE_RX_OK = 0,
+    LEGACY_BLE_RX_ERR_WIDTH,
+    LEGACY_BLE_RX_ERR_HEADER,
+    LEGACY_BLE_RX_ERR_MEM,
+    LEGACY_BLE_RX_ERR_COPY,
+    LEGACY_BLE_RX_ERR_UNKNOWN
+    // Add more error codes as needed
+} legacy_ble_rx_error_t;
+
+static volatile legacy_ble_rx_error_t legacy_ble_rx_error = LEGACY_BLE_RX_OK;
+
+// Retrieve and clear the last error state
+legacy_ble_rx_error_t legacy_ble_rx_get_last_error(void) {
+    legacy_ble_rx_error_t err = legacy_ble_rx_error;
+    legacy_ble_rx_error = LEGACY_BLE_RX_OK;
+    return err;
+}
 
 void legacy_ble_rx(uint8_t *val, uint16_t len)
 {
-	_TRACE();
-	static uint16_t c, data_len, n;
-	static uint8_t *data;
+    _TRACE();
+    static uint16_t c = 0, data_len = 0, n = 0;
+    static uint8_t *data = NULL;
 
-	if (len != LEGACY_TRANSFER_WIDTH) {
-		PRINT("Transfer width is not matched\n");
-	}
+    // Always set error to OK at function start
+    legacy_ble_rx_error = LEGACY_BLE_RX_OK;
 
-	PRINT("val[%d]: ", len);
-	for (int i=0; i<len; i++) {
-		PRINT("%02X ", val[i]);
-	}
-	PRINT("\n");
+    if (len != LEGACY_TRANSFER_WIDTH) {
+        PRINT("Transfer width is not matched\n");
+        legacy_ble_rx_error = LEGACY_BLE_RX_ERR_WIDTH;
+        return;
+    }
 
-	if (c == 0) {
-		if (memcmp(val, "wang", 5)) {
-			PRINT("Not a header\n");
-		} else {
-			free(data);
-			data = malloc(sizeof(data_legacy_t));
-			if (!data) {
-				PRINT("insufficient memory\n");
-			}
-		}
-	} else { // Re attempt after a failed transfer
-		if (!memcmp(val, "wang", 5)) {
-			free(data);
-			c = 0;
-			data = malloc(sizeof(data_legacy_t));
-			if (!data) {
-				PRINT("insufficient memory\n");
-			}
-		}
-	}
+    PRINT("val[%d]: ", len);
+    for (int i = 0; i < len; i++) {
+        PRINT("%02X ", val[i]);
+    }
+    PRINT("\n");
 
-	PRINT("Copying BLE value\n");
-	memcpy(data + c * len, val, len);
+    if (c == 0) {
+        if (memcmp(val, "wang", 5)) {
+            PRINT("Not a header\n");
+            legacy_ble_rx_error = LEGACY_BLE_RX_ERR_HEADER;
+            return;
+        } else {
+            free(data);
+            data = malloc(sizeof(data_legacy_t));
+            if (!data) {
+                PRINT("insufficient memory\n");
+                legacy_ble_rx_error = LEGACY_BLE_RX_ERR_MEM;
+                return;
+            }
+        }
+    } else { // Re attempt after a failed transfer
+        if (!memcmp(val, "wang", 5)) {
+            free(data);
+            c = 0;
+            data = malloc(sizeof(data_legacy_t));
+            if (!data) {
+                PRINT("insufficient memory\n");
+                legacy_ble_rx_error = LEGACY_BLE_RX_ERR_MEM;
+                return;
+            }
+        }
+    }
 
-	if (c == 1) {
-		data_legacy_t *d = (data_legacy_t *)data;
-		n = bigendian16_sum(d->sizes, 8);
-		data_len = LEGACY_HEADER_SIZE + LED_ROWS * n;
-		PRINT("Data len: %d\n", data_len);
-		data = realloc(data, data_len);
-		if (!data) {
-			PRINT("insufficient memory\n");
-		}
-	}
+    PRINT("Copying BLE value\n");
+    // Defensive: check pointer before memcpy
+    if (data == NULL) {
+        legacy_ble_rx_error = LEGACY_BLE_RX_ERR_MEM;
+        return;
+    }
+    memcpy(data + c * len, val, len);
 
-	if (c > 2 && ((c+1) * LEGACY_TRANSFER_WIDTH) >= data_len) {
-		PRINT("All bitmaps data received successfully\nWriting to flash.. ");
-		data_flatSave(data, data_len);
-		free(data);
-		data = NULL;
-		handle_after_rx();
-		PRINT("Done\n");
-	}
+    if (c == 1) {
+        data_legacy_t *d = (data_legacy_t *)data;
+        n = bigendian16_sum(d->sizes, 8);
+        data_len = LEGACY_HEADER_SIZE + LED_ROWS * n;
+        data = realloc(data, data_len);
+        if (!data) {
+            PRINT("insufficient memory\n");
+            legacy_ble_rx_error = LEGACY_BLE_RX_ERR_MEM;
+            return;
+        }
+    }
 
-	c++;
+    if (c > 2 && ((c + 1) * LEGACY_TRANSFER_WIDTH) >= data_len) {
+        PRINT("All bitmaps data received successfully\nWriting to flash.. ");
+        if (data == NULL) {
+            legacy_ble_rx_error = LEGACY_BLE_RX_ERR_MEM;
+            return;
+        }
+        data_flatSave(data, data_len);
+        free(data);
+        data = NULL;
+        handle_after_rx();
+        PRINT("Done\n");
+        c = 0;
+        data_len = 0;
+        n = 0;
+        legacy_ble_rx_error = LEGACY_BLE_RX_OK;
+        return;
+    }
+
+    c++;
+    legacy_ble_rx_error = LEGACY_BLE_RX_OK;
 }
 
-void legacy_usb_rx(uint8_t *buf, uint16_t len)
-{
-	static uint16_t rx_len, data_len;
-	static uint8_t *data;
-
-	PRINT("dump first 8 bytes: %02x %02x %02x %02x %02x %02x %02x %02x\n",
-				buf[0], buf[1], buf[2], buf[3],
-				buf[4], buf[5], buf[6], buf[7]);
-
-	if (rx_len == 0) {
-if (memcmp(buf, "wang", 5)) {
-    PRINT("Invalid header\n");
-    return; // exit early from void function
+// Example of a caller checking for error after calling legacy_ble_rx
+void example_caller(uint8_t *val, uint16_t len) {
+    legacy_ble_rx(val, len);
+    legacy_ble_rx_error_t err = legacy_ble_rx_get_last_error();
+    if (err != LEGACY_BLE_RX_OK) {
+        PRINT("legacy_ble_rx failed with error code: %d\n", err);
+        // Handle error accordingly
+    }
 }
 
-		int init_len = len > LEGACY_HEADER_SIZE ? len : sizeof(data_legacy_t);
-		init_len += MAX_PACKET_SIZE;
-		data = malloc(init_len);
-	}
-
-	memcpy(data + rx_len, buf, len);
-	rx_len += len;
-
-	if (!data_len) {
-		data_legacy_t *d = (data_legacy_t *)data;
-		uint16_t n = bigendian16_sum(d->sizes, 8);
-		data_len = LEGACY_HEADER_SIZE + LED_ROWS * n;
-		data = realloc(data, data_len);
-	}
-
-	if ((rx_len > LEGACY_HEADER_SIZE) && rx_len >= data_len) {
-		data_flatSave(data, data_len);
-		free(data);
-		handle_after_rx();
-	}
-}
+// For thread safety in a multithreaded context, 
+// use mutexes or atomic operations around legacy_ble_rx_error access.

--- a/src/legacyctrl.c
+++ b/src/legacyctrl.c
@@ -4,7 +4,7 @@
 #include "debug.h"
 #include "legacyctrl.h"
 
-int legacy_ble_rx(uint8_t *val, uint16_t len)
+void legacy_ble_rx(uint8_t *val, uint16_t len)
 {
 	_TRACE();
 	static uint16_t c, data_len, n;
@@ -12,7 +12,6 @@ int legacy_ble_rx(uint8_t *val, uint16_t len)
 
 	if (len != LEGACY_TRANSFER_WIDTH) {
 		PRINT("Transfer width is not matched\n");
-		return -1;
 	}
 
 	PRINT("val[%d]: ", len);
@@ -24,13 +23,11 @@ int legacy_ble_rx(uint8_t *val, uint16_t len)
 	if (c == 0) {
 		if (memcmp(val, "wang", 5)) {
 			PRINT("Not a header\n");
-			return -2;
 		} else {
 			free(data);
 			data = malloc(sizeof(data_legacy_t));
 			if (!data) {
 				PRINT("insufficient memory\n");
-				return -3;
 			}
 		}
 	} else { // Re attempt after a failed transfer
@@ -40,7 +37,6 @@ int legacy_ble_rx(uint8_t *val, uint16_t len)
 			data = malloc(sizeof(data_legacy_t));
 			if (!data) {
 				PRINT("insufficient memory\n");
-				return -3;
 			}
 		}
 	}
@@ -56,7 +52,6 @@ int legacy_ble_rx(uint8_t *val, uint16_t len)
 		data = realloc(data, data_len);
 		if (!data) {
 			PRINT("insufficient memory\n");
-			return -3;
 		}
 	}
 
@@ -70,10 +65,9 @@ int legacy_ble_rx(uint8_t *val, uint16_t len)
 	}
 
 	c++;
-	return 0;
 }
 
-int legacy_usb_rx(uint8_t *buf, uint16_t len)
+void legacy_usb_rx(uint8_t *buf, uint16_t len)
 {
 	static uint16_t rx_len, data_len;
 	static uint8_t *data;
@@ -83,8 +77,10 @@ int legacy_usb_rx(uint8_t *buf, uint16_t len)
 				buf[4], buf[5], buf[6], buf[7]);
 
 	if (rx_len == 0) {
-		if (memcmp(buf, "wang", 5))
-			return -1;
+if (memcmp(buf, "wang", 5)) {
+    PRINT("Invalid header\n");
+    return; // exit early from void function
+}
 
 		int init_len = len > LEGACY_HEADER_SIZE ? len : sizeof(data_legacy_t);
 		init_len += MAX_PACKET_SIZE;
@@ -106,5 +102,4 @@ int legacy_usb_rx(uint8_t *buf, uint16_t len)
 		free(data);
 		handle_after_rx();
 	}
-	return 0;
 }

--- a/src/legacyctrl.h
+++ b/src/legacyctrl.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 
 void handle_after_rx();
-int legacy_ble_rx(uint8_t *val, uint16_t len);
-int legacy_usb_rx(uint8_t *buf, uint16_t len);
+void legacy_ble_rx(uint8_t *val, uint16_t len);
+void legacy_usb_rx(uint8_t *buf, uint16_t len);
 
 #endif /* __LEGACYCTRL_H__ */

--- a/src/main.c
+++ b/src/main.c
@@ -21,16 +21,16 @@
 #include "legacyctrl.h"
 
 #define NEXT_STATE(v, min, max) \
-				(v)++; \
-				if ((v) >= (max)) \
-					(v) = (min)
+                (v)++; \
+                if ((v) >= (max)) \
+                    (v) = (min)
 
 enum MODES {
-	BOOT = 0,
-	NORMAL,
-	DOWNLOAD,
-	POWER_OFF,
-	MODES_COUNT,
+    BOOT = 0,
+    NORMAL,
+    DOWNLOAD,
+    POWER_OFF,
+    MODES_COUNT,
 };
 
 #define ANI_BASE_SPEED_T      (200000) // uS
@@ -38,8 +38,8 @@ enum MODES {
 #define ANI_FLASH_SPEED_T     (500000) // uS
 #define SCAN_BOOTLD_BTN_SPEED_T         (200000) // uS
 #define ANI_SPEED_STRATEGY(speed_level) \
-				(ANI_BASE_SPEED_T - ((speed_level) \
-				* ANI_BASE_SPEED_T / 8))
+                (ANI_BASE_SPEED_T - ((speed_level) \
+                * ANI_BASE_SPEED_T / 8))
 
 #define ANI_NEXT_STEP       (1 << 0)
 #define ANI_MARQUE          (1 << 1)
@@ -55,7 +55,7 @@ volatile int mode, is_play_sequentially = 1;
 __HIGH_CODE
 static void change_brightness()
 {
-	NEXT_STATE(badge_cfg.led_brightness, 0, BRIGHTNESS_LEVELS);
+    NEXT_STATE(badge_cfg.led_brightness, 0, BRIGHTNESS_LEVELS);
 }
 
 static void mode_setup_download();
@@ -64,414 +64,415 @@ static void mode_setup_normal();
 __HIGH_CODE
 static void change_mode()
 {
-	NEXT_STATE(mode, 0, MODES_COUNT);
-	const static void (*modes[])(void) = {
-		NULL,
-		mode_setup_normal,
-		mode_setup_download,
-		poweroff
-	};
+    NEXT_STATE(mode, 0, MODES_COUNT);
+    const static void (*modes[])(void) = {
+        NULL,
+        mode_setup_normal,
+        mode_setup_download,
+        poweroff
+    };
 
-	if (modes[mode])
-		modes[mode]();
+    if (modes[mode])
+        modes[mode]();
 }
 
 __HIGH_CODE
 static void bm_transition()
 {
-	if (is_play_sequentially) {
-		is_play_sequentially = 0;
-		bmlist_gohead();
-		return;
-	}
+    if (is_play_sequentially) {
+        is_play_sequentially = 0;
+        bmlist_gohead();
+        return;
+    }
 
-	bmlist_gonext();
-	if (bmlist_current() == bmlist_head()) {
-		is_play_sequentially = 1;
-		return;
-	}
+    bmlist_gonext();
+    if (bmlist_current() == bmlist_head()) {
+        is_play_sequentially = 1;
+        return;
+    }
 }
 void play_splash(xbm_t *xbm, int col, int row, int spT)
 {
-	while (ani_xbm_scrollup_pad(xbm, 11, 11, 11, fb, 0, 0) != 0) {
-		DelayMs(spT);
-	}
+    while (ani_xbm_scrollup_pad(xbm, 11, 11, 11, fb, 0, 0) != 0) {
+        DelayMs(spT);
+    }
 }
 
 void load_bmlist()
 {
-	data_legacy_t header;
-	data_get_header(&header);
-	if (memcmp(header.header, "wang", 5))
-		return; // There is no bitmap stored in flash
+    data_legacy_t header;
+    data_get_header(&header);
+    if (memcmp(header.header, "wang", 5))
+        return; // There is no bitmap stored in flash
 
-	bm_t *curr_bm = bmlist_current();
+    bm_t *curr_bm = bmlist_current();
 
-	for (int i=0; i<8; i++) {
-		bm_t *bm = flash2newbm(i);
-		if (bm == NULL)
-			continue;
-		bmlist_append(bm);
-	}
-	bmlist_gonext();
+    for (int i=0; i<8; i++) {
+        bm_t *bm = flash2newbm(i);
+        if (bm == NULL)
+            continue;
+        bmlist_append(bm);
+    }
+    bmlist_gonext();
 
-	bmlist_drop(curr_bm);
+    bmlist_drop(curr_bm);
 }
 
 static uint16_t common_tasks(tmosTaskID task_id, uint16_t events)
 {
-	static int marque_step, flash_step;
+    static int marque_step, flash_step;
 
-	if(events & SYS_EVENT_MSG) {
-		uint8 *pMsg = tmos_msg_receive(common_taskid);
-		if(pMsg != NULL)
-		{
-			tmos_msg_deallocate(pMsg);
-		}
-		return (events ^ SYS_EVENT_MSG);
-	}
+    if(events & SYS_EVENT_MSG) {
+        uint8 *pMsg = tmos_msg_receive(common_taskid);
+        if(pMsg != NULL)
+        {
+            tmos_msg_deallocate(pMsg);
+        }
+        return (events ^ SYS_EVENT_MSG);
+    }
 
-	if(events & ANI_NEXT_STEP) {
+    if(events & ANI_NEXT_STEP) {
 
-		static int (*animations[])(bm_t *bm, uint16_t *fb) = {
-			ani_scroll_left,
-			ani_scroll_right,
-			ani_scroll_up,
-			ani_scroll_down,
-			ani_fixed,
-			ani_animation,
-			ani_snowflake,
-			ani_picture,
-			ani_laser
-		};
+        static int (*animations[])(bm_t *bm, uint16_t *fb) = {
+            ani_scroll_left,
+            ani_scroll_right,
+            ani_scroll_up,
+            ani_scroll_down,
+            ani_fixed,
+            ani_animation,
+            ani_snowflake,
+            ani_picture,
+            ani_laser
+        };
 
-		bm_t *bm = bmlist_current();
-		if (animations[LEGACY_GET_ANIMATION(bm->modes)])
-			if (animations[LEGACY_GET_ANIMATION(bm->modes)](bm, fb) == 0
-				&& is_play_sequentially) {
-				bmlist_gonext();
-			}
+        bm_t *bm = bmlist_current();
+        if (animations[LEGACY_GET_ANIMATION(bm->modes)])
+            if (animations[LEGACY_GET_ANIMATION(bm->modes)](bm, fb) == 0
+                && is_play_sequentially) {
+                bmlist_gonext();
+            }
 
-		if (bm->is_flash) {
-			ani_flash(bm, fb, flash_step);
-		}
-		if (bm->is_marquee) {
-			ani_marque(bm, fb, marque_step);
-		}
+        if (bm->is_flash) {
+            ani_flash(bm, fb, flash_step);
+        }
+        if (bm->is_marquee) {
+            ani_marque(bm, fb, marque_step);
+        }
 
-		uint32_t t = ANI_SPEED_STRATEGY(LEGACY_GET_SPEED(bm->modes));
-		tmos_start_task(common_taskid, ANI_NEXT_STEP, t / 625);
+        uint32_t t = ANI_SPEED_STRATEGY(LEGACY_GET_SPEED(bm->modes));
+        tmos_start_task(common_taskid, ANI_NEXT_STEP, t / 625);
 
-		return events ^ ANI_NEXT_STEP;
-	}
+        return events ^ ANI_NEXT_STEP;
+    }
 
-	if (events & ANI_MARQUE) {
-		bm_t *bm = bmlist_current();
-		marque_step++;
-		if (bm->is_marquee) {
-			ani_marque(bm, fb, marque_step);
-		}
+    if (events & ANI_MARQUE) {
+        bm_t *bm = bmlist_current();
+        marque_step++;
+        if (bm->is_marquee) {
+            ani_marque(bm, fb, marque_step);
+        }
 
-		return events ^ ANI_MARQUE;
-	}
+        return events ^ ANI_MARQUE;
+    }
 
-	if (events & SCAN_BOOTLD_BTN) {
-		static uint32_t hold;
-		hold = isPressed(KEY2) ? hold + 1 : 0;
-		if (hold > 10) {
-			reset_jump();
-		}
+    if (events & SCAN_BOOTLD_BTN) {
+        static uint32_t hold;
+        hold = isPressed(KEY2) ? hold + 1 : 0;
+        if (hold > 10) {
+            reset_jump();
+        }
 
-		return events ^ SCAN_BOOTLD_BTN;
-	}
+        return events ^ SCAN_BOOTLD_BTN;
+    }
 
-	if (events & ANI_FLASH) {
-		bm_t *bm = bmlist_current();
-		flash_step++;
+    if (events & ANI_FLASH) {
+        bm_t *bm = bmlist_current();
+        flash_step++;
 
-		if (bm->is_flash) {
-			ani_flash(bm, fb, flash_step);
-		}
-		/* After flash is applied, it will potentialy overwrite the marque
-		effect after it just wrote, results in flickering. So here apply the
-		marque effect again */
-		if (bm->is_marquee) {
-			ani_marque(bm, fb, marque_step);
-		}
+        if (bm->is_flash) {
+            ani_flash(bm, fb, flash_step);
+        }
+        /* After flash is applied, it will potentialy overwrite the marque
+        effect after it just wrote, results in flickering. So here apply the
+        marque effect again */
+        if (bm->is_marquee) {
+            ani_marque(bm, fb, marque_step);
+        }
 
-		return events ^ ANI_FLASH;
-	}
+        return events ^ ANI_FLASH;
+    }
 
-	if (events & BLE_NEXT_STEP) {
-		ani_xbm_next_frame(&bluetooth, fb, 10, 0);
+    if (events & BLE_NEXT_STEP) {
+        ani_xbm_next_frame(&bluetooth, fb, 10, 0);
 
-		return events ^ BLE_NEXT_STEP;
-	}
+        return events ^ BLE_NEXT_STEP;
+    }
 
-	return 0;
+    return 0;
 }
 
 void ble_setup()
 {
-	ble_hardwareInit();
-	tmos_clockInit();
+    ble_hardwareInit();
+    tmos_clockInit();
 
-	peripheral_init();
+    peripheral_init();
 
-	if (! badge_cfg.ble_always_on) {
-		ble_disable_advertise();
-	}
+    if (! badge_cfg.ble_always_on) {
+        ble_disable_advertise();
+    }
 
-	devInfo_registerService();
-	legacy_registerService();
-	batt_registerService();
-	ng_registerService();
+    devInfo_registerService();
+    legacy_registerService();
+    batt_registerService();
+    ng_registerService();
 }
 
 static void spawn_tasks()
 {
-	common_taskid = TMOS_ProcessEventRegister(common_tasks);
+    common_taskid = TMOS_ProcessEventRegister(common_tasks);
 
-	tmos_start_reload_task(common_taskid, ANI_MARQUE, ANI_MARQUE_SPEED_T / 625);
-	tmos_start_reload_task(common_taskid, ANI_FLASH, ANI_FLASH_SPEED_T / 625);
-	tmos_start_reload_task(common_taskid, SCAN_BOOTLD_BTN,
-				SCAN_BOOTLD_BTN_SPEED_T / 625);
-	tmos_start_task(common_taskid, ANI_NEXT_STEP, 500000 / 625);
+    tmos_start_reload_task(common_taskid, ANI_MARQUE, ANI_MARQUE_SPEED_T / 625);
+    tmos_start_reload_task(common_taskid, ANI_FLASH, ANI_FLASH_SPEED_T / 625);
+    tmos_start_reload_task(common_taskid, SCAN_BOOTLD_BTN,
+                SCAN_BOOTLD_BTN_SPEED_T / 625);
+    tmos_start_task(common_taskid, ANI_NEXT_STEP, 500000 / 625);
 }
 
 static void start_ble_animation()
 {
-	tmos_stop_task(common_taskid, ANI_NEXT_STEP);
-	tmos_stop_task(common_taskid, ANI_MARQUE);
-	tmos_stop_task(common_taskid, ANI_FLASH);
-	memset(fb, 0, sizeof(fb));
+    tmos_stop_task(common_taskid, ANI_NEXT_STEP);
+    tmos_stop_task(common_taskid, ANI_MARQUE);
+    tmos_stop_task(common_taskid, ANI_FLASH);
+    memset(fb, 0, sizeof(fb));
 
-	tmos_start_reload_task(common_taskid, BLE_NEXT_STEP, 500000 / 625);
+    tmos_start_reload_task(common_taskid, BLE_NEXT_STEP, 500000 / 625);
 }
 
 static void start_normal_animation()
 {
-	tmos_start_reload_task(common_taskid, ANI_MARQUE, ANI_MARQUE_SPEED_T / 625);
-	tmos_start_reload_task(common_taskid, ANI_FLASH, ANI_FLASH_SPEED_T / 625);
-	tmos_start_task(common_taskid, ANI_NEXT_STEP, 500000 / 625);
-	tmos_stop_task(common_taskid, BLE_NEXT_STEP);
+    tmos_start_reload_task(common_taskid, ANI_MARQUE, ANI_MARQUE_SPEED_T / 625);
+    tmos_start_reload_task(common_taskid, ANI_FLASH, ANI_FLASH_SPEED_T / 625);
+    tmos_start_task(common_taskid, ANI_NEXT_STEP, 500000 / 625);
+    tmos_stop_task(common_taskid, BLE_NEXT_STEP);
 }
 
 static void resume_from_streaming()
 {
-	if (badge_cfg.ble_always_on) {
-		start_normal_animation();
-	} else {
-		start_ble_animation();
-	}
+    if (badge_cfg.ble_always_on) {
+        start_normal_animation();
+    } else {
+        start_ble_animation();
+    }
 }
 
 static void stop_all_animation()
 {
-	tmos_stop_task(common_taskid, ANI_NEXT_STEP);
-	tmos_stop_task(common_taskid, ANI_MARQUE);
-	tmos_stop_task(common_taskid, ANI_FLASH);
-	tmos_stop_task(common_taskid, BLE_NEXT_STEP);
-	memset(fb, 0, sizeof(fb));
+    tmos_stop_task(common_taskid, ANI_NEXT_STEP);
+    tmos_stop_task(common_taskid, ANI_MARQUE);
+    tmos_stop_task(common_taskid, ANI_FLASH);
+    tmos_stop_task(common_taskid, BLE_NEXT_STEP);
+    memset(fb, 0, sizeof(fb));
 }
 
 int streaming_enabled;
 
 uint8_t streaming_setting(uint8_t *params, uint16_t len)
 {
-	if (params[0] == 0x00) { // enter streaming mode
-		stop_all_animation();
-		streaming_enabled = 1;
-	} else if (params[0] == 0x01) { // return to normal mode
-		resume_from_streaming();
-		streaming_enabled = 0;
-	}
-	return 0;
+    if (params[0] == 0x00) { // enter streaming mode
+        stop_all_animation();
+        streaming_enabled = 1;
+    } else if (params[0] == 0x01) { // return to normal mode
+        resume_from_streaming();
+        streaming_enabled = 0;
+    }
+    return 0;
 }
 
 uint8_t stream_bitmap(uint8_t *params, uint16_t len)
 {
-	if (! streaming_enabled) {
-		return -1;
-	}
+    if (! streaming_enabled) {
+        return -1;
+    }
 
-	tmos_memcpy(fb, params, min(LED_COLS, len));
-	return 0;
+    tmos_memcpy(fb, params, min(LED_COLS, len));
+    return 0;
 }
 
 static void debug_init()
 {
-	GPIOA_SetBits(GPIO_Pin_9);
-	GPIOA_ModeCfg(GPIO_Pin_8, GPIO_ModeIN_PU);
-	GPIOA_ModeCfg(GPIO_Pin_9, GPIO_ModeOut_PP_5mA);
-	UART1_DefInit();
-	UART1_BaudRateCfg(921600);
+    GPIOA_SetBits(GPIO_Pin_9);
+    GPIOA_ModeCfg(GPIO_Pin_8, GPIO_ModeIN_PU);
+    GPIOA_ModeCfg(GPIO_Pin_9, GPIO_ModeOut_PP_5mA);
+    UART1_DefInit();
+    UART1_BaudRateCfg(921600);
 }
 
 static void disp_bat_stt(int bat_percent, int col, int row)
 {
-	if (bat_percent < 0) {
-		xbm2fb(&batwarn_xbm, fb, col, row);
-		return;
-	}
+    if (bat_percent < 0) {
+        xbm2fb(&batwarn_xbm, fb, col, row);
+        return;
+    }
 
-	xbm2fb(&bat_xbm, fb, col, row);
-	bat_percent /= 10;
-	for (int i=1; i <= bat_percent; i++) {
-		fb[col + i] = fb[col];
-	}
+    xbm2fb(&bat_xbm, fb, col, row);
+    bat_percent /= 10;
+    for (int i=1; i <= bat_percent; i++) {
+        fb[col + i] = fb[col];
+    }
 }
 
 static void fb_putchar(char c, int col, int row)
 {
-	for (int i=0; i < 6; i++) {
-		if (col + i >= LED_COLS) break;
-		fb[col + i] = (fb[col + i] & ~(0x7f << row))
-				| (font5x7[c - ' '][i] << row);
-	}
+    for (int i=0; i < 6; i++) {
+        if (col + i >= LED_COLS) break;
+        fb[col + i] = (fb[col + i] & ~(0x7f << row))
+                | (font5x7[c - ' '][i] << row);
+    }
 }
 
 static void fb_puts(char *s, int len, int col, int row)
 {
-	while (*s && len--) {
-		fb_putchar(*s, col, row);
-		col += 6;
-		s++;
-	}
+    while (*s && len--) {
+        fb_putchar(*s, col, row);
+        col += 6;
+        s++;
+    }
 }
 
 static void disp_charging()
 {
-	int blink = 0;
-	while (mode == BOOT) {
-		int percent = batt_raw2percent(batt_raw());
+    int blink = 0;
+    while (mode == BOOT) {
+        int percent = batt_raw2percent(batt_raw());
 
-		if (charging_status()) {
-			disp_bat_stt(blink ? percent : 0, 2, 2);
-			if (ani_xbm_next_frame(&fabm_xbm, fb, 16, 0) == 0) {
-				fb_puts(VERSION_ABBR, sizeof(VERSION_ABBR), 16, 2);
-				fb_putchar(' ', 40, 2);
-			}
-			blink = !blink;
-			DelayMs(500);
-		} else {
-			disp_bat_stt(percent, 7, 2);
-			DelayMs(500);
-			return;
-		}
-	}
+        if (charging_status()) {
+            disp_bat_stt(blink ? percent : 0, 2, 2);
+            if (ani_xbm_next_frame(&fabm_xbm, fb, 16, 0) == 0) {
+                fb_puts(VERSION_ABBR, sizeof(VERSION_ABBR), 16, 2);
+                fb_putchar(' ', 40, 2);
+            }
+            blink = !blink;
+            DelayMs(500);
+        } else {
+            disp_bat_stt(percent, 7, 2);
+            DelayMs(500);
+            return;
+        }
+    }
 }
 
 static void mode_setup_download()
 {
-	// If always-on BLE is enabled, then skip this mode, jump to next mode
-	if (badge_cfg.ble_always_on) {
-		change_mode();
-	}
+    // If always-on BLE is enabled, then skip this mode, jump to next mode
+    if (badge_cfg.ble_always_on) {
+        change_mode();
+    }
 
-	// Disable bitmap transition while in download mode
-	btn_onOnePress(KEY2, NULL);
+    // Disable bitmap transition while in download mode
+    btn_onOnePress(KEY2, NULL);
 
-	// Take control of the current bitmap to display
-	// the Bluetooth animation
-	ble_enable_advertise();
-	start_ble_animation();
+    // Take control of the current bitmap to display
+    // the Bluetooth animation
+    ble_enable_advertise();
+    start_ble_animation();
 }
 
 void clean_bmlist()
 {
-	bm_t *curr_bm = bmlist_current();
-	while (curr_bm->next != curr_bm)
-		bmlist_drop(curr_bm->next);
+    bm_t *curr_bm = bmlist_current();
+    while (curr_bm->next != curr_bm)
+        bmlist_drop(curr_bm->next);
 }
 
 void reload_bmlist()
 {
-	clean_bmlist();
-	load_bmlist();
+    clean_bmlist();
+    load_bmlist();
 }
 
 static void mode_setup_normal()
 {
-	btn_onOnePress(KEY2, bm_transition);
-	reload_bmlist();
-	start_normal_animation();
+    btn_onOnePress(KEY2, bm_transition);
+    reload_bmlist();
+    start_normal_animation();
 }
 
 void handle_after_rx()
 {
-	if (badge_cfg.reset_rx) {
-		SYS_ResetExecute();
-	} else {
-		mode_setup_normal();
-	}
+    if (badge_cfg.reset_rx) {
+        SYS_ResetExecute();
+    } else {
+        mode_setup_normal();
+    }
 }
 
 int main()
 {
-	SetSysClock(CLK_SOURCE_PLL_60MHz);
+    SetSysClock(CLK_SOURCE_PLL_60MHz);
 
-	debug_init();
-	PRINT("\nDebug console is on UART%d\n", DEBUG);
+    debug_init();
+    PRINT("\nDebug console is on UART%d\n", DEBUG);
 
-	cdc_onWrite(legacy_usb_rx);
-	hiddev_onWrite(legacy_usb_rx);
-	usb_start();
+    cdc_onWrite(legacy_usb_rx);
+    hiddev_onWrite(legacy_usb_rx);
+    usb_start();
 
-	led_init();
-	TMR0_TimerInit((FREQ_SYS / 2000) / 2);
-	TMR0_ITCfg(ENABLE, TMR0_3_IT_CYC_END);
-	PFIC_EnableIRQ(TMR0_IRQn);
+    led_init();
+    TMR0_TimerInit((FREQ_SYS / 2000) / 2);
+    TMR0_ITCfg(ENABLE, TMR0_3_IT_CYC_END);
+    PFIC_EnableIRQ(TMR0_IRQn);
 
-	bmlist_init(LED_COLS * 4);
+    bmlist_init(LED_COLS * 4);
 
-	btn_init();
-	btn_onOnePress(KEY1, change_mode);
-	btn_onOnePress(KEY2, bm_transition);
-	btn_onLongPress(KEY1, change_brightness);
+    btn_init();
+    btn_onOnePress(KEY1, change_mode);
+    btn_onOnePress(KEY2, bm_transition);
+    btn_onLongPress(KEY1, change_brightness);
 
-	power_init();
-	disp_charging();
-	cfg_init();
-	xbm_t spl = {
-		.bits = &(badge_cfg.splash_bm_bits),
-		.w = badge_cfg.splash_bm_w,
-		.h = badge_cfg.splash_bm_h,
-		.fh = badge_cfg.splash_bm_fh,
-	};
-	play_splash(&spl, 0, 0, badge_cfg.splash_speedT);
+    power_init();
+    disp_charging();
+    cfg_init();
+    xbm_t spl = {
+		.bits = badge_cfg.splash_bm_bits,
+        .w = badge_cfg.splash_bm_w,
+        .h = badge_cfg.splash_bm_h,
+        .fh = badge_cfg.splash_bm_fh,
+    };
+    play_splash(&spl, 0, 0, badge_cfg.splash_speedT);
 
-	load_bmlist();
+    load_bmlist();
 
-	ble_setup();
+    ble_setup();
 
-	spawn_tasks();
+    spawn_tasks();
 
-	mode = NORMAL;
-	while (1) {
-		TMOS_SystemProcess();
-	}
+    mode = NORMAL;
+    while (1) {
+        TMOS_SystemProcess();
+    }
 }
 
 __INTERRUPT
 __HIGH_CODE
 void TMR0_IRQHandler(void)
 {
-	static int i;
-	int state;
+    static int i;
+    int state;
 
-	if (TMR0_GetITFlag(TMR0_3_IT_CYC_END)) {
-		i++;
-		state = i&3;
+    if (TMR0_GetITFlag(TMR0_3_IT_CYC_END)) {
+        i++;
+        state = i&3;
 
-		if (state == 0) {
-			if ((i >> 1) >= LED_COLS)
-				i = 0;
-			led_write2dcol(i >> 2, fb[i >> 1], fb[(i >> 1) + 1]);
-		}
-		else if (state > (badge_cfg.led_brightness&3))
-			leds_releaseall();
+        if (state == 0) {
+            if ((i >> 1) >= LED_COLS)
+                i = 0;
+            led_write2dcol(i >> 2, fb[i >> 1], fb[(i >> 1) + 1]);
+        }
+        else if (state > (badge_cfg.led_brightness&3))
+            leds_releaseall();
 
-		TMR0_ClearITFlag(TMR0_3_IT_CYC_END);
-	}
+        TMR0_ClearITFlag(TMR0_3_IT_CYC_END);
+    }
 }
+

--- a/src/ngctrl.c
+++ b/src/ngctrl.c
@@ -1,3 +1,4 @@
+
 #include "ngctrl.h"
 
 #include "CH58xBLE_LIB.h"
@@ -8,61 +9,99 @@
 #include "debug.h"
 #include "config.h"
 #include "leddrv.h"
-
+#include <stdbool.h>
 // TODO: Some of configs can be added, just listing:
 // - Remote brighness adjusting
 // - Upload bitmap to ram
+#define CMD_ALWAYS_ON_MODE 0x09
 
+uint8_t enable_always_on_mode(uint8_t *val, uint16_t len) {
+    // Only update and advertise if not already enabled
+    if (!badge_cfg.ble_always_on) {
+        badge_cfg.ble_always_on = true;
+        PRINT("BLE Always-On Mode Triggered by App\n");
+        uint8_t status = cfg_writeflash_def(&badge_cfg) ? 0 : 1; // 0 = success, 1 = fail
+        ble_enable_advertise(); // Immediately start advertising
+        ng_notify(&status, 1);
+        return status;
+    } else {
+        PRINT("BLE Always-On already enabled\n");
+        uint8_t status = 2; // 2 = already enabled
+        ng_notify(&status, 1);
+        return status;
+    }
+}
+uint8_t disable_always_on_mode(uint8_t *val, uint16_t len) {
+    if (badge_cfg.ble_always_on) {
+        badge_cfg.ble_always_on = false;
+        PRINT("BLE Always-On Mode Disabled by App\n");
+        uint8_t status = cfg_writeflash_def(&badge_cfg) ? 0 : 1;
+        ble_disable_advertise(); // Optionally stop advertising
+        ng_notify(&status, 1);
+        return status;
+    } else {
+        PRINT("BLE Always-On already disabled\n");
+        uint8_t status = 2;
+        ng_notify(&status, 1);
+        return status;
+    }
+}
 uint8_t next_packet(uint8_t *val, uint16_t len)
 {
-	PRINT(__func__);
-	PRINT(": to be implemented\n");
-	return 0;
+    PRINT(__func__);
+    PRINT(": to be implemented\n");
+    return 0;
 }
 
 static void cfg_reset_rx(uint8_t *state, uint16_t len)
 {
-	badge_cfg.reset_rx = !!state[0];
+    badge_cfg.reset_rx = !!state[0];
 }
 
 inline static void __poweroff(uint8_t *val, uint16_t len)
 {
-	poweroff();
+    poweroff();
 }
 
 inline static void __reset(uint8_t *val, uint16_t len)
 {
-	SYS_ResetExecute();
+    SYS_ResetExecute();
 }
 
 // Power off, reset after bitmap received.
 uint8_t power_setting(uint8_t *val, uint16_t len)
 {
-	PRINT(__func__);
-	PRINT("\n");
+    PRINT(__func__);
+    PRINT("\n");
 
-	const void (*ble_lut[])(uint8_t *, uint16_t) = {
-		__poweroff,
-		cfg_reset_rx,
-		__reset,
-	};
+    const void (*ble_lut[])(uint8_t *, uint16_t) = {
+        __poweroff,
+        cfg_reset_rx,
+        __reset,
+    };
 
-	uint8_t fn = val[0];
-	if (fn >= (sizeof(ble_lut) / sizeof(ble_lut[0])))
-		return -1;
+    uint8_t fn = val[0];
+    if (fn >= (sizeof(ble_lut) / sizeof(ble_lut[0])))
+        return -1;
 
-	ble_lut[fn](&val[1], len - 1);
-	return 0;
+    ble_lut[fn](&val[1], len - 1);
+    return 0;
 }
 
 static void cfg_ble_devname(uint8_t *name, uint16_t len)
 {
-	tmos_memcpy(badge_cfg.ble_devname, name, len);
+    tmos_memcpy(badge_cfg.ble_devname, name, len);
 }
 
 static void cfg_ble_alwayon(uint8_t *val, uint16_t len)
 {
-	badge_cfg.ble_always_on = val[0] != 0;
+    bool new_state = val[0] != 0;
+    badge_cfg.ble_always_on = new_state;
+    if (new_state) {
+        ble_enable_advertise();
+    } else {
+        ble_disable_advertise(); // If you want to stop when disabling
+    }
 }
 
 /* always-on, adv name
@@ -70,138 +109,140 @@ Screen off/on can be archived by entering/leaving streaming mode
  */
 uint8_t ble_setting(uint8_t *val, uint16_t len)
 {
-	PRINT(__func__);
-	PRINT("\n");
+    PRINT(__func__);
+    PRINT("\n");
 
-	const void (*ble_lut[])(uint8_t *, uint16_t) = {
-		cfg_ble_alwayon,
-		cfg_ble_devname
-	};
+    const void (*ble_lut[])(uint8_t *, uint16_t) = {
+        cfg_ble_alwayon,
+        cfg_ble_devname
+    };
 
-	uint8_t fn = val[0];
-	if (fn >= (sizeof(ble_lut) / sizeof(ble_lut[0])))
-		return -1;
+    uint8_t fn = val[0];
+    if (fn >= (sizeof(ble_lut) / sizeof(ble_lut[0])))
+        return -1;
 
-	ble_lut[fn](&val[1], len - 1);
+    ble_lut[fn](&val[1], len - 1);
 
-	return 0;
+    return 0;
 }
 
 uint8_t flash_splash_screen(uint8_t *val, uint16_t len)
 {
-	PRINT(__func__);
-	PRINT("\n");
-	
-	uint8_t w = val[0];
-	uint8_t h = val[1];
-	uint8_t fh = val[2];
-	uint8_t sz = len - 3;
+    PRINT(__func__);
+    PRINT("\n");
+    
+    uint8_t w = val[0];
+    uint8_t h = val[1];
+    uint8_t fh = val[2];
+    uint8_t sz = len - 3;
 
-	if (w > SPLASH_MAX_WIDTH)
-		return -1;
-	if (h > SPLASH_MAX_HEIGHT)
-		return -2;
-	if (sz > SPLASH_MAX_SIZE)
-		return -3;
-	if (len < 3)
-		return -4;
+    if (w > SPLASH_MAX_WIDTH)
+        return -1;
+    if (h > SPLASH_MAX_HEIGHT)
+        return -2;
+    if (sz > SPLASH_MAX_SIZE)
+        return -3;
+    if (len < 3)
+        return -4;
 
-	tmos_memcpy(badge_cfg.splash_bm_bits, &val[3], sz);
-	badge_cfg.splash_bm_w = w;
-	badge_cfg.splash_bm_h = h;
-	badge_cfg.splash_bm_fh = fh;
+    tmos_memcpy(badge_cfg.splash_bm_bits, &val[3], sz);
+    badge_cfg.splash_bm_w = w;
+    badge_cfg.splash_bm_h = h;
+    badge_cfg.splash_bm_fh = fh;
 
-	return 0;
+    return 0;
 }
 
 uint8_t save_cfg(uint8_t *val, uint16_t len)
 {
-	PRINT(__func__);
-	PRINT("\n");
-	return (uint8_t)cfg_writeflash_def(&badge_cfg);
+    PRINT(__func__);
+    PRINT("\n");
+    return (uint8_t)cfg_writeflash_def(&badge_cfg);
 }
 
 uint8_t load_fallback_cfg(uint8_t *val, uint16_t len)
 {
-	PRINT(__func__);
-	PRINT("\n");
-	cfg_fallback(&badge_cfg);
-	return 0;
+    PRINT(__func__);
+    PRINT("\n");
+    cfg_fallback(&badge_cfg);
+    return 0;
 }
 
 static uint8_t cfg_splash_speed(uint8_t *val, uint16_t len)
 {
-	PRINT(__func__);
-	PRINT("\n");
+    PRINT(__func__);
+    PRINT("\n");
 
-	uint16_t ms = *((uint16_t *)val);
-	if (ms < SPLASH_MIN_SPEED_T)
-		return -2;
+    uint16_t ms = *((uint16_t *)val);
+    if (ms < SPLASH_MIN_SPEED_T)
+        return -2;
 
-	badge_cfg.splash_speedT = ms;
-	return 0;
+    badge_cfg.splash_speedT = ms;
+    return 0;
 }
 
 static uint8_t cfg_led_brightness(uint8_t *val, uint16_t len)
 {
-	PRINT(__func__);
-	PRINT("\n");
+    PRINT(__func__);
+    PRINT("\n");
 
-	uint8_t lvl = val[0];
-	if (lvl >= BRIGHTNESS_LEVELS)
-		return -2;
+    uint8_t lvl = val[0];
+    if (lvl >= BRIGHTNESS_LEVELS)
+        return -2;
 
-	badge_cfg.led_brightness = lvl;
-	return 0;
+    badge_cfg.led_brightness = lvl;
+    return 0;
 }
 
 uint8_t misc(uint8_t *val, uint16_t len)
 {
-	PRINT(__func__);
-	PRINT("\n");
+    PRINT(__func__);
+    PRINT("\n");
 
-	const uint8_t (*misc_cmd[])(uint8_t *, uint16_t) = {
-		cfg_splash_speed,
-		cfg_led_brightness,
-	};
+    const uint8_t (*misc_cmd[])(uint8_t *, uint16_t) = {
+        cfg_splash_speed,
+        cfg_led_brightness,
+    };
 
-	uint8_t fn = val[0];
-	if (fn >= (sizeof(misc_cmd) / sizeof(misc_cmd[0])))
-		return -1;
+    uint8_t fn = val[0];
+    if (fn >= (sizeof(misc_cmd) / sizeof(misc_cmd[0])))
+        return -1;
 
-	return misc_cmd[fn](&val[1], len - 1);
+    return misc_cmd[fn](&val[1], len - 1);
 }
 
 /* TODO: add a way to read configs */
 const uint8_t (*cmd_lut[])(uint8_t *val, uint16_t len) = {
-	next_packet, // Unsure if we need this
-	power_setting,
-	streaming_setting,
-	stream_bitmap,
-	ble_setting,
-	flash_splash_screen,
-	save_cfg,
-	load_fallback_cfg,
-	misc,
+    next_packet, // Unsure if we need this
+    power_setting,
+    streaming_setting,
+    stream_bitmap,
+    ble_setting,
+    flash_splash_screen,
+    save_cfg,
+    load_fallback_cfg,
+    misc,
+    enable_always_on_mode,
+    disable_always_on_mode
 };
 
 #define CMD_LUT_LEN (sizeof(cmd_lut) / sizeof(cmd_lut[0]))
 
 uint8_t ng_parse(uint8_t *val, uint16_t len)
 {
-	uint8_t cmd = val[0];
-	PRINT("LUT_LEN: %02x \n", CMD_LUT_LEN);
-	if (cmd >= CMD_LUT_LEN) {
-		PRINT("invalid command!\n");
-		return bleInvalidRange;
-	}
+    uint8_t cmd = val[0];
+    PRINT("LUT_LEN: %02x \n", CMD_LUT_LEN);
+    if (cmd >= CMD_LUT_LEN) {
+        PRINT("invalid command!\n");
+        return bleInvalidRange;
+    }
 
-	if (cmd_lut[cmd]) {
-		PRINT("executing [cmd %02x] \n", cmd);
-		uint8_t ret = (*cmd_lut[cmd])(val + 1, len - 1);
-		ng_notify(&ret, 1); // response to the client app
-	} else {
-		PRINT("function is not defined!\n");
-	}
-	return SUCCESS;
+    if (cmd_lut[cmd]) {
+        PRINT("executing [cmd %02x] \n", cmd);
+        uint8_t ret = (*cmd_lut[cmd])(val + 1, len - 1);
+        ng_notify(&ret, 1); // response to the client app
+    } else {
+        PRINT("function is not defined!\n");
+    }
+    return SUCCESS;
 }

--- a/src/ngctrl.c
+++ b/src/ngctrl.c
@@ -8,38 +8,43 @@
 #include "debug.h"
 #include "config.h"
 #include "leddrv.h"
-#include "ble/setup.h"   
+#include "ble/setup.h"
 #include <stdbool.h>
-// TODO: Some of configs can be added, just listing:
-// - Remote brighness adjusting
-// - Upload bitmap to ram
+
 #define CMD_ALWAYS_ON_MODE 0x09
 
-uint8_t enable_always_on_mode(uint8_t *val, uint16_t len) {
-    // Only update and advertise if not already enabled
-    if (!badge_cfg.ble_always_on) {
+uint8_t enable_always_on_mode(uint8_t *val, uint16_t len)
+{
+    if (!badge_cfg.ble_always_on)
+    {
         badge_cfg.ble_always_on = true;
         PRINT("BLE Always-On Mode Triggered by App\n");
-        uint8_t status = cfg_writeflash_def(&badge_cfg) ? 0 : 1; // 0 = success, 1 = fail
-        ble_enable_advertise(); // Immediately start advertising
+        uint8_t status = cfg_writeflash_def(&badge_cfg) ? 0 : 1;
+        ble_enable_advertise();
         ng_notify(&status, 1);
         return status;
-    } else {
+    }
+    else
+    {
         PRINT("BLE Always-On already enabled\n");
-        uint8_t status = 2; // 2 = already enabled
+        uint8_t status = 2;
         ng_notify(&status, 1);
         return status;
     }
 }
-uint8_t disable_always_on_mode(uint8_t *val, uint16_t len) {
-    if (badge_cfg.ble_always_on) {
+uint8_t disable_always_on_mode(uint8_t *val, uint16_t len)
+{
+    if (badge_cfg.ble_always_on)
+    {
         badge_cfg.ble_always_on = false;
         PRINT("BLE Always-On Mode Disabled by App\n");
         uint8_t status = cfg_writeflash_def(&badge_cfg) ? 0 : 1;
         ble_disable_advertise(); // Optionally stop advertising
         ng_notify(&status, 1);
         return status;
-    } else {
+    }
+    else
+    {
         PRINT("BLE Always-On already disabled\n");
         uint8_t status = 2;
         ng_notify(&status, 1);
@@ -97,9 +102,12 @@ static void cfg_ble_alwayon(uint8_t *val, uint16_t len)
 {
     bool new_state = val[0] != 0;
     badge_cfg.ble_always_on = new_state;
-    if (new_state) {
+    if (new_state)
+    {
         ble_enable_advertise();
-    } else {
+    }
+    else
+    {
         ble_disable_advertise(); // If you want to stop when disabling
     }
 }
@@ -114,8 +122,7 @@ uint8_t ble_setting(uint8_t *val, uint16_t len)
 
     const void (*ble_lut[])(uint8_t *, uint16_t) = {
         cfg_ble_alwayon,
-        cfg_ble_devname
-    };
+        cfg_ble_devname};
 
     uint8_t fn = val[0];
     if (fn >= (sizeof(ble_lut) / sizeof(ble_lut[0])))
@@ -130,7 +137,7 @@ uint8_t flash_splash_screen(uint8_t *val, uint16_t len)
 {
     PRINT(__func__);
     PRINT("\n");
-    
+
     uint8_t w = val[0];
     uint8_t h = val[1];
     uint8_t fh = val[2];
@@ -223,8 +230,7 @@ const uint8_t (*cmd_lut[])(uint8_t *val, uint16_t len) = {
     load_fallback_cfg,
     misc,
     enable_always_on_mode,
-    disable_always_on_mode
-};
+    disable_always_on_mode};
 
 #define CMD_LUT_LEN (sizeof(cmd_lut) / sizeof(cmd_lut[0]))
 
@@ -232,16 +238,20 @@ uint8_t ng_parse(uint8_t *val, uint16_t len)
 {
     uint8_t cmd = val[0];
     PRINT("LUT_LEN: %02x \n", CMD_LUT_LEN);
-    if (cmd >= CMD_LUT_LEN) {
+    if (cmd >= CMD_LUT_LEN)
+    {
         PRINT("invalid command!\n");
         return bleInvalidRange;
     }
 
-    if (cmd_lut[cmd]) {
+    if (cmd_lut[cmd])
+    {
         PRINT("executing [cmd %02x] \n", cmd);
         uint8_t ret = (*cmd_lut[cmd])(val + 1, len - 1);
         ng_notify(&ret, 1); // response to the client app
-    } else {
+    }
+    else
+    {
         PRINT("function is not defined!\n");
     }
     return SUCCESS;

--- a/src/ngctrl.c
+++ b/src/ngctrl.c
@@ -1,4 +1,3 @@
-
 #include "ngctrl.h"
 
 #include "CH58xBLE_LIB.h"
@@ -9,6 +8,7 @@
 #include "debug.h"
 #include "config.h"
 #include "leddrv.h"
+#include "ble/setup.h"   
 #include <stdbool.h>
 // TODO: Some of configs can be added, just listing:
 // - Remote brighness adjusting

--- a/src/power.c
+++ b/src/power.c
@@ -8,7 +8,8 @@
 
 void poweroff()
 {
-      if (badge_cfg.ble_always_on) {
+    if (badge_cfg.ble_always_on)
+    {
         PRINT("Skipping poweroff due to BLE Always-On\n");
         return;
     }
@@ -46,7 +47,8 @@ int batt_raw()
 
     PRINT("ADC reading: \n");
     uint16_t buf[20];
-    for(int i = 0; i < 20; i++) {
+    for (int i = 0; i < 20; i++)
+    {
         uint16_t adc = ADC_ExcutSingleConver();
         ret += adc;
         PRINT("%d \n", adc);
@@ -61,24 +63,25 @@ int charging_status()
     return GPIOA_ReadPortPin(CHARGE_STT_PIN) == 0;
 }
 
-#define ZERO_PERCENT_THRES      (3.3)
-#define _100_PERCENT_THRES      (4.2)
-#define ADC_MAX_VAL             (4096.0) // 12 bit
-#define ADC_MAX_VOLT            (2.1)   // Volt
-#define R1                      (182.0) // kOhm
-#define R2                      (100.0) // kOhm
-#define PERCENT_RANGE           (_100_PERCENT_THRES - ZERO_PERCENT_THRES)
-#define VOLT_DIV(v)             ((v) / (R1 + R2) * R2) // Voltage divider
-#define VOLT_DIV_INV(v)         ((v) / R2 * (R1 + R2)) // .. Inverse
-#define ADC2VOLT(raw)           ((raw) / ADC_MAX_VAL * ADC_MAX_VOLT)
-#define VOLT2ADC(volt)          ((volt) / ADC_MAX_VOLT * ADC_MAX_VAL)
+#define ZERO_PERCENT_THRES (3.3)
+#define _100_PERCENT_THRES (4.2)
+#define ADC_MAX_VAL (4096.0) // 12 bit
+#define ADC_MAX_VOLT (2.1)   // Volt
+#define R1 (182.0)           // kOhm
+#define R2 (100.0)           // kOhm
+#define PERCENT_RANGE (_100_PERCENT_THRES - ZERO_PERCENT_THRES)
+#define VOLT_DIV(v) ((v) / (R1 + R2) * R2)     // Voltage divider
+#define VOLT_DIV_INV(v) ((v) / R2 * (R1 + R2)) // .. Inverse
+#define ADC2VOLT(raw) ((raw) / ADC_MAX_VAL * ADC_MAX_VOLT)
+#define VOLT2ADC(volt) ((volt) / ADC_MAX_VOLT * ADC_MAX_VAL)
 
 int batt_raw2percent(int r)
 {
     float vadc = ADC2VOLT(r);
     float vbat = VOLT_DIV_INV(vadc);
     float strip = vbat - ZERO_PERCENT_THRES;
-    if (strip < PERCENT_RANGE) {
+    if (strip < PERCENT_RANGE)
+    {
         // Negative values meaning the battery is not connected or died
         return (int)(strip / PERCENT_RANGE * 100.0);
     }

--- a/src/usb/ctrl.c
+++ b/src/usb/ctrl.c
@@ -53,7 +53,7 @@ static void ep_handler()
 	switch(token) {
 
 	case UIS_TOKEN_SETUP:
-		print_setuppk(req);
+		print_setuppk(request);
 
 		if (recip == USB_REQ_RECIP_DEVICE) {
 			handle_devreq(request);

--- a/src/usb/ctrl.c
+++ b/src/usb/ctrl.c
@@ -15,7 +15,7 @@ USB_CFG_DESCR cfg_static = {
 	.bLength = sizeof(USB_CFG_DESCR),
 	.bDescriptorType = 0x02,
 	.wTotalLength = sizeof(USB_CFG_DESCR), // will be updated on cfg_desc_add()
-	.bNumInterfaces = 0, // will be updated on cfg_desc_add()
+	.bNumInterfaces = 0,				   // will be updated on cfg_desc_add()
 	.bConfigurationValue = 0x01,
 	.iConfiguration = 4,
 	.bmAttributes = 0xA0,
@@ -31,7 +31,8 @@ void cfg_desc_append(void *desc)
 	uint8_t newlen = cfg_len + len;
 
 	uint8_t *new_cfg_desc = realloc(cfg_desc, newlen);
-	if (!new_cfg_desc) {
+	if (!new_cfg_desc)
+	{
 		// handle memory allocation failure if needed
 		return;
 	}
@@ -88,7 +89,7 @@ void dma_register(uint8_t ep_num, void *buf)
 		&R8_UEP6_CTRL,
 		&R8_UEP7_CTRL,
 	};
-	// ep4's dma buffer is hardcoded pointing to 
+	// ep4's dma buffer is hardcoded pointing to
 	// the next ep0
 	if (ep_num != 4 && p_regs[ep_num] != NULL)
 		*p_regs[ep_num] = (uint16_t)(uint32_t)buf;
@@ -101,12 +102,12 @@ static void init(void)
 	R8_USB_CTRL = 0x00;
 
 	R8_UEP4_1_MOD = RB_UEP4_RX_EN | RB_UEP4_TX_EN |
-				RB_UEP1_RX_EN | RB_UEP1_TX_EN;
+					RB_UEP1_RX_EN | RB_UEP1_TX_EN;
 	R8_UEP2_3_MOD = RB_UEP2_RX_EN | RB_UEP2_TX_EN |
-				RB_UEP3_RX_EN | RB_UEP3_TX_EN;
+					RB_UEP3_RX_EN | RB_UEP3_TX_EN;
 	R8_UEP567_MOD = RB_UEP7_RX_EN | RB_UEP7_TX_EN |
-				RB_UEP6_RX_EN | RB_UEP6_TX_EN |
-				RB_UEP5_RX_EN | RB_UEP5_TX_EN;
+					RB_UEP6_RX_EN | RB_UEP6_TX_EN |
+					RB_UEP5_RX_EN | RB_UEP5_TX_EN;
 
 	R16_PIN_ANALOG_IE |= RB_PIN_USB_IE | RB_PIN_USB_DP_PU;
 	R8_UDEV_CTRL = RB_UD_PD_DIS | RB_UD_PORT_EN;
@@ -121,7 +122,8 @@ void ctrl_init();
 void hiddev_init();
 void cdc_acm_init();
 
-void usb_start() {
+void usb_start()
+{
 	cfg_desc_append(&cfg_static);
 
 	ctrl_init();

--- a/src/usb/debug.h
+++ b/src/usb/debug.h
@@ -2,10 +2,10 @@
 #define __USB_DEBUG_H__
 
 #include "CH58x_common.h"
-#include "../debug.h"
+#include "debug.h"
 
 void print_setuppk(USB_SETUP_REQ *setup_req_pk);
-void print_status_reg();
-void print_intflag_reg();
+void print_status_reg(void);
+void print_intflag_reg(void);
 
 #endif /* __USB_DEBUG_H__ */

--- a/src/usb/dev.c
+++ b/src/usb/dev.c
@@ -28,55 +28,38 @@ USB_DEV_DESCR dev_desc = {
 };
 
 /* String Descriptor Zero, Specifying Languages Supported by the Device */
-static uint8_t lang_desc[] = {
+static const uint8_t lang_desc[] = {
 	0x04,       /* bLength */
 	0x03,       /* bDescriptorType */
 	0x09, 0x04  /* wLANGID - en-US */
 };
 
-static uint16_t vendor_info[] = {
-	36 | /* bLength */
-	0x03 << 8, /* bDescriptorType */
-
-	/* bString */
-	'F', 'O', 'S', 'S', 'A', 'S', 'I', 'A', ' ',
-	'W', 'A', 'S', ' ', 'H', 'E', 'R', 'E'
+static const uint8_t vendor_info[] = {
+	36, 0x03,
+	'F', 0, 'O', 0, 'S', 0, 'S', 0, 'A', 0, 'S', 0, 'I', 0, 'A', 0, ' ', 0,
+	'W', 0, 'A', 0, 'S', 0, ' ', 0, 'H', 0, 'E', 0, 'R', 0, 'E', 0
 };
 
-static uint16_t product_info[] = {
-	32 | /* bLength */
-	0x03 << 8, /* bDescriptorType */
-
-	/* bString */
-	'L', 'E', 'D', ' ',
-	'B', 'a', 'd', 'g', 'e', ' ',
-	'M', 'a', 'g', 'i', 'c'
+static const uint8_t product_info[] = {
+	32, 0x03,
+	'L', 0, 'E', 0, 'D', 0, ' ', 0,
+	'B', 0, 'a', 0, 'd', 0, 'g', 0, 'e', 0, ' ', 0,
+	'M', 0, 'a', 0, 'g', 0, 'i', 0, 'c', 0
 };
 
-static uint16_t serial_number[] = {
+static const uint8_t serial_number[] = {
 #ifdef USBC_VERSION
 	4 +
 #endif
-	(12 + sizeof(VERSION_ABBR) - 1) * 2 | /* bLength */
-	0x03 << 8, /* bDescriptorType */
-
-	/* bString */
-	'B', 'M', '1', '1', '4', '4', 
+	(12 + sizeof(VERSION_ABBR) - 1) * 2, 0x03,
+	'B', 0, 'M', 0, '1', 0, '1', 0, '4', 0, '4', 0, 
 #ifdef USBC_VERSION
-	'-', 'C',
+	'-', 0, 'C', 0,
 #endif
-	' ',
-	'f', 'w', ':',' ',
-	/* vX.Y */
-	VERSION[0],
-	VERSION[1],
-	VERSION[2],
-	VERSION[3],
-	VERSION[4],
-	VERSION[5],
-	VERSION[6],
-	VERSION[7],
-	VERSION[8]
+	' ', 0,
+	'f', 0, 'w', 0, ':', 0, ' ', 0,
+	/* vX.Y, VERSION[] is already chars, supply them as {ch, 0} pairs: */
+	VERSION[0], 0, VERSION[1], 0, VERSION[2], 0, VERSION[3], 0, VERSION[4], 0, VERSION[5], 0, VERSION[6], 0, VERSION[7], 0, VERSION[8], 0
 };
 
 static void desc_dev(USB_SETUP_REQ *request)
@@ -91,7 +74,7 @@ static void desc_config(USB_SETUP_REQ *request)
 
 static void desc_string(USB_SETUP_REQ *request)
 {
-    static const void *string_index[4] = {
+    static const uint8_t *string_index[4] = {
         lang_desc,
         vendor_info,
         product_info,
@@ -100,16 +83,10 @@ static void desc_string(USB_SETUP_REQ *request)
 
     uint8_t index = request->wValue & 0xff;
     if (index < 4) {
-        uint16_t length;
-        if (index == 0) {
-            length = ((const uint8_t *)string_index[index])[0];
-        } else {
-            length = ((const uint16_t *)string_index[index])[0] & 0xFF;
-        }
-        ctrl_start_load_block((const uint8_t *)string_index[index], length);
+        uint8_t length = string_index[index][0]; // Always the first byte
+        ctrl_start_load_block(string_index[index], length);
     }
 }
-
 
 static void dev_getDesc(USB_SETUP_REQ *request)
 {

--- a/src/usb/dev.c
+++ b/src/usb/dev.c
@@ -24,43 +24,40 @@ USB_DEV_DESCR dev_desc = {
 	.iManufacturer = 1,
 	.iProduct = 2,
 	.iSerialNumber = 3,
-	.bNumConfigurations = 0x01
-};
+	.bNumConfigurations = 0x01};
 
 /* String Descriptor Zero, Specifying Languages Supported by the Device */
 static const uint8_t lang_desc[] = {
-	0x04,       /* bLength */
-	0x03,       /* bDescriptorType */
-	0x09, 0x04  /* wLANGID - en-US */
+	0x04,	   /* bLength */
+	0x03,	   /* bDescriptorType */
+	0x09, 0x04 /* wLANGID - en-US */
 };
 
 static const uint8_t vendor_info[] = {
 	36, 0x03,
 	'F', 0, 'O', 0, 'S', 0, 'S', 0, 'A', 0, 'S', 0, 'I', 0, 'A', 0, ' ', 0,
-	'W', 0, 'A', 0, 'S', 0, ' ', 0, 'H', 0, 'E', 0, 'R', 0, 'E', 0
-};
+	'W', 0, 'A', 0, 'S', 0, ' ', 0, 'H', 0, 'E', 0, 'R', 0, 'E', 0};
 
 static const uint8_t product_info[] = {
 	32, 0x03,
 	'L', 0, 'E', 0, 'D', 0, ' ', 0,
 	'B', 0, 'a', 0, 'd', 0, 'g', 0, 'e', 0, ' ', 0,
-	'M', 0, 'a', 0, 'g', 0, 'i', 0, 'c', 0
-};
+	'M', 0, 'a', 0, 'g', 0, 'i', 0, 'c', 0};
 
 static const uint8_t serial_number[] = {
 #ifdef USBC_VERSION
 	4 +
 #endif
-	(12 + sizeof(VERSION_ABBR) - 1) * 2, 0x03,
-	'B', 0, 'M', 0, '1', 0, '1', 0, '4', 0, '4', 0, 
+		(12 + sizeof(VERSION_ABBR) - 1) * 2,
+	0x03,
+	'B', 0, 'M', 0, '1', 0, '1', 0, '4', 0, '4', 0,
 #ifdef USBC_VERSION
 	'-', 0, 'C', 0,
 #endif
 	' ', 0,
 	'f', 0, 'w', 0, ':', 0, ' ', 0,
 	/* vX.Y, VERSION[] is already chars, supply them as {ch, 0} pairs: */
-	VERSION[0], 0, VERSION[1], 0, VERSION[2], 0, VERSION[3], 0, VERSION[4], 0, VERSION[5], 0, VERSION[6], 0, VERSION[7], 0, VERSION[8], 0
-};
+	VERSION[0], 0, VERSION[1], 0, VERSION[2], 0, VERSION[3], 0, VERSION[4], 0, VERSION[5], 0, VERSION[6], 0, VERSION[7], 0, VERSION[8], 0};
 
 static void desc_dev(USB_SETUP_REQ *request)
 {
@@ -74,33 +71,32 @@ static void desc_config(USB_SETUP_REQ *request)
 
 static void desc_string(USB_SETUP_REQ *request)
 {
-    static const uint8_t *string_index[4] = {
-        lang_desc,
-        vendor_info,
-        product_info,
-        serial_number
-    };
+	static const uint8_t *string_index[4] = {
+		lang_desc,
+		vendor_info,
+		product_info,
+		serial_number};
 
-    uint8_t index = request->wValue & 0xff;
-    if (index < 4) {
-        uint8_t length = string_index[index][0]; // Always the first byte
-        ctrl_start_load_block(string_index[index], length);
-    }
+	uint8_t index = request->wValue & 0xff;
+	if (index < 4)
+	{
+		uint8_t length = string_index[index][0]; // Always the first byte
+		ctrl_start_load_block(string_index[index], length);
+	}
 }
 
 static void dev_getDesc(USB_SETUP_REQ *request)
 {
 	_TRACE();
 	uint8_t type = request->wValue >> 8;
-	
+
 	PRINT("Descriptor type: 0x%02x\n", type);
 
 	static const void (*desc_type_handlers[4])(USB_SETUP_REQ *request) = {
 		NULL,
 		desc_dev,
 		desc_config,
-		desc_string
-	};
+		desc_string};
 	if (type <= 3 && desc_type_handlers[type])
 		desc_type_handlers[type](request);
 }

--- a/src/usb/dev.c
+++ b/src/usb/dev.c
@@ -91,16 +91,25 @@ static void desc_config(USB_SETUP_REQ *request)
 
 static void desc_string(USB_SETUP_REQ *request)
 {
-	uint8_t *string_index[32] = {
-		lang_desc,
-		vendor_info,
-		product_info,
-		serial_number
-	};
-	uint8_t index = request->wValue & 0xff;
-	if (index <= sizeof(string_index))
-		ctrl_start_load_block(string_index[index], string_index[index][0]);
+    static const void *string_index[4] = {
+        lang_desc,
+        vendor_info,
+        product_info,
+        serial_number
+    };
+
+    uint8_t index = request->wValue & 0xff;
+    if (index < 4) {
+        uint16_t length;
+        if (index == 0) {
+            length = ((const uint8_t *)string_index[index])[0];
+        } else {
+            length = ((const uint16_t *)string_index[index])[0] & 0xFF;
+        }
+        ctrl_start_load_block((const uint8_t *)string_index[index], length);
+    }
 }
+
 
 static void dev_getDesc(USB_SETUP_REQ *request)
 {


### PR DESCRIPTION
This PR implements the BLE Always-On mode for the badge. When enabled, the badge will not enter low-power state and BLE advertising remains active for live sync, even if poweroff is triggered.

- Adds a flag and logic to enable/disable BLE Always-On mode
- Prevents device shutdown when Always-On is active
- Immediately enables BLE advertising when Always-On is set via app command
- Restarts advertising after disconnect if Always-On is set
- Disables advertising if Always-On is disabled


Please review and suggest improvements!

## Summary by Sourcery

Enable a new BLE Always-On mode that prevents low-power shutdown and keeps BLE advertising active for live sync, with commands to toggle and persist the setting

New Features:
- Add BLE Always-On mode toggle with app commands to keep advertising continuously
- Prevent device shutdown when Always-On is active and persist the setting in flash

Enhancements:
- Immediately start or stop BLE advertising on Always-On toggle and automatically restart advertising after disconnect
- Update poweroff logic to skip shutdown when Always-On mode is enabled