### PR TITLE
Clarify bootloader instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Select the `badgemagic-ch582.bin` file and click 'Download'.
 Where badgemagic-ch582.bin is the binary downloaded above, the .elf file also
 works.
 
+### Updating
+
+Once the open source firmware is installed, there is no further need to remove the battery or short-circuit C3 to enter ISP mode. Simply long-press KEY2 to enter ISP mode. Then, flash updated firmware with
+
+```sh
+wchisp config reset
+wchisp flash badgemagic-ch582.bin
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ the boot pin is pulled down in one of two ways:
 - Alternatively, connect the USB, press and hold KEY2, then short and release
   the C3 capacitor.
 
-If the badge has succesfully entered ISP mode, a single pixel roughly in the middle of the display will be lit. The badge will stay in ISP mode for approximately ten seconds before rebooting into normal mode.
+If the badge has successfully entered ISP mode, a single pixel roughly in the middle of the display will be lit. The badge will stay in ISP mode for approximately ten seconds before rebooting into normal mode.
 
 You can also check `dmesg` if the chip has entered the ISP mode with idVendor=4348 and
 idProduct=55e0.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ the boot pin is pulled down in one of two ways:
 
 If the badge has successfully entered ISP mode, a single pixel roughly in the middle of the display will be lit. The badge will stay in ISP mode for approximately ten seconds before rebooting into normal mode.
 
-You can also check `dmesg` if the chip has entered the ISP mode with idVendor=4348 and
-idProduct=55e0.
+On Linux, you can also check `dmesg` if the chip has entered the ISP mode with idVendor=4348 and idProduct=55e0.
 
 ![c3](assets/burn-badge.svg)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Hardware details and information to build an open firmware for Bluetooth LED bad
 
 ## Installation
 
-### Unix
 Install [wchisp](https://github.com/ch32-rs/wchisp?tab=readme-ov-file#installing).
 
 Download prebuilt binaries from [release](https://github.com/fossasia/badgemagic-firmware/releases) or [the latest development builds](https://github.com/fossasia/badgemagic-firmware/tree/bin).
@@ -17,12 +16,14 @@ the boot pin is pulled down in one of two ways:
 - Alternatively, connect the USB, press and hold KEY2, then short and release
   the C3 capacitor.
 
-Then check `dmesg` if the chip has entered the ISP mode with idVendor=4348 and
+If the badge has succesfully entered ISP mode, a single pixel roughly in the middle of the display will be lit. The badge will stay in ISP mode for approximately ten seconds before rebooting into normal mode.
+
+You can also check `dmesg` if the chip has entered the ISP mode with idVendor=4348 and
 idProduct=55e0.
 
 ![c3](assets/burn-badge.svg)
 
-Then run:
+With the badge in ISP mode, run:
 
 ```sh
 wchisp config reset
@@ -30,8 +31,8 @@ wchisp flash badgemagic-ch582.bin
 ```
 
 ### Windows
-Install and run [wchisp studio](https://www.wch-ic.com/downloads/WCHISPTool_Setup_exe.html)
-Connect the badge via USB and enter bootloader mode.
+On Windows, you have the option to install and run [wchisp studio](https://www.wch-ic.com/downloads/WCHISPTool_Setup_exe.html) instead of the wchisp CLI tool.
+Connect the badge via USB and enter bootloader mode, per the instructions above.
 
 The device will automatically appear in the UI.
 


### PR DESCRIPTION
- Remove Unix header under Installation section, as the instructions there also apply to Windows.
- Add note that a single pixel in the center of the screen is lit when in ISP mode.

## Summary by Sourcery

Clarify and unify bootloader installation instructions across platforms, including visual feedback for ISP mode and Windows-specific guidance.

Documentation:
- Document the visual indicator (single lit pixel) and timeout behavior when the badge is in ISP mode.
- Clarify that the wchisp CLI installation and flashing steps apply generally, with Windows documentation focusing on the optional GUI tool and referencing the shared bootloader instructions.