### PR TITLE
Fix power button hang

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -51,6 +51,7 @@ static tmosTaskID common_taskid = INVALID_TASK_ID ;
 
 volatile uint16_t fb[LED_COLS] = {0};
 volatile int mode, is_play_sequentially = 1;
+volatile int pending_poweroff = 0;  // Flag for deferred power-off
 
 __HIGH_CODE
 static void change_brightness()
@@ -65,11 +66,19 @@ __HIGH_CODE
 static void change_mode()
 {
 	NEXT_STATE(mode, 0, MODES_COUNT);
+
+	// CRITICAL: Don't call poweroff() from ISR context!
+	// Set flag and let main loop handle it
+	if (mode == POWER_OFF) {
+		pending_poweroff = 1;
+		return;
+	}
+
 	const static void (*modes[])(void) = {
 		NULL,
 		mode_setup_normal,
 		mode_setup_download,
-		poweroff
+		NULL  // poweroff handled via pending_poweroff flag
 	};
 
 	if (modes[mode])
@@ -449,6 +458,11 @@ int main()
 
 	mode = NORMAL;
 	while (1) {
+		// Handle deferred power-off from main context (NOT ISR!)
+		if (pending_poweroff) {
+			pending_poweroff = 0;
+			poweroff();  // Safe: called from main loop, not ISR
+		}
 		TMOS_SystemProcess();
 	}
 }

--- a/src/power.c
+++ b/src/power.c
@@ -77,3 +77,11 @@ int batt_raw2percent(int r)
 	}
 	return 100;
 }
+
+__INTERRUPT
+__HIGH_CODE
+void GPIOA_IRQHandler(void)
+{
+	// Just clear the interrupt flag - LowPower_Shutdown handles reset after __WFI
+	GPIOA_ClearITFlagBit(KEY1_PIN | CHARGE_STT_PIN);
+}


### PR DESCRIPTION
Fixes badge hang when pressing power button multiple times.

The issue was that poweroff() was called directly from button ISR context, causing __WFI to execute inside an interrupt handler which hangs the CPU.

Fix defers poweroff to main loop and adds GPIOA_IRQHandler for wake interrupt handling.

## Summary by Sourcery

Defer badge power-off handling from interrupt context to the main loop and add a GPIO interrupt handler for wake-related interrupts.

Bug Fixes:
- Prevent CPU hang when the power button is pressed multiple times by avoiding poweroff execution from ISR context.

Enhancements:
- Introduce a deferred power-off mechanism using a pending flag processed in the main loop.
- Add a GPIOA interrupt handler to clear wake-related interrupt flags without performing shutdown logic in the ISR.