### PR TITLE
Handle button events outside interrupt context

### DIFF
--- a/src/button.h
+++ b/src/button.h
@@ -19,5 +19,7 @@ enum keys {
 void btn_onOnePress(int key, void (*handler)(void));
 void btn_onLongPress(int key, void (*handler)(void));
 void btn_init();
+void btn_init_task(void);
+void btn_tick(void);
 
 #endif /* __BUTTON_H__ */

--- a/src/main.c
+++ b/src/main.c
@@ -344,6 +344,7 @@ static void disp_charging()
 {
 	int blink = 0;
 	while (mode == BOOT) {
+		btn_tick();
 		int percent = batt_raw2percent(batt_raw());
 
 		if (charging_status()) {
@@ -446,6 +447,7 @@ int main()
 	ble_setup();
 
 	spawn_tasks();
+	btn_init_task();
 
 	mode = NORMAL;
 	while (1) {


### PR DESCRIPTION
A lot of the button tasks configure TMOS tasks, which cause a lot of graphical glitches, e.g. when the bluetooth icon is drawn but the other tasks for rendering the effects are actively running. This PR moves the button task to be polled inside the primary TMOS system process, which means it is guaranteed to run any button handlers when the main task isn't running.

This also, coincidentally, fixes the "WFI inside the interrupt handler" issue causing poweroff to hang.

## Summary by Sourcery

Move button handling out of interrupt context into a TMOS task-driven polling model to avoid graphical glitches and interrupt-related hangs.

Bug Fixes:
- Defer button press handlers from the timer interrupt to the main TMOS task loop, resolving poweroff hangs caused by WFI in interrupt context and reducing rendering glitches when button actions trigger display updates.

Enhancements:
- Introduce a dedicated TMOS button task and pending-flag mechanism so button events are processed safely in the main event loop rather than directly in the interrupt handler.
- Allow button polling during the boot charging display loop to ensure button input remains responsive while charging graphics are shown.