### PR TITLE
docs: fix MRS toolchain version in build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ version repeatedly.
 Set the toolchain location, e.g.:
 
 ```sh
-export PREFIX=../MRS_Toolchain_Linux_x64_V1.91/RISC-V_Embedded_GCC/bin/riscv-none-embed-
+export PREFIX=../MRS_Toolchain_Linux_x64_V1.92/RISC-V_Embedded_GCC/bin/riscv-none-embed-
 ```
 
 Simply run `make` to build the firmware for the Micro USB version, with the output directed to the `build/` directory. To build for the USB-C version of the badge and specify a custom output directory:


### PR DESCRIPTION
Just a simple fix in build instructions to mach the download link of MRS toolchain

ps: this is my first pr to this repo so please tell if everything looks good :)

## Summary by Sourcery

Documentation:
- Correct the MRS toolchain version in the README build instructions to align with the downloadable toolchain archive.