### PR TITLE
Fix buffer size mismatch (#114)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -30,6 +30,7 @@ void cfg_fallback()
 	badge_cfg.splash_speedT = 30; // ms
 
 	int splash_size = ALIGN_1BYTE(splash.w) * splash.h;
+	memset(badge_cfg.splash_bm_bits, 0, sizeof(badge_cfg.splash_bm_bits));
 	memcpy(badge_cfg.splash_bm_bits, splash.bits, splash_size);
 	badge_cfg.splash_bm_w = splash.w;
 	badge_cfg.splash_bm_h = splash.h;

--- a/src/config.c
+++ b/src/config.c
@@ -9,6 +9,7 @@
 #include "util/crc.h"
 
 #include "ISP583.h"
+#include "CH58xBLE_LIB.h"
 #include <stdlib.h>
 
 #define CFG_SIZE sizeof(badge_cfg_t)
@@ -20,9 +21,9 @@ badge_cfg_t badge_cfg;
 void cfg_fallback()
 {
 	badge_cfg.ble_always_on = 0;
-	memcpy(badge_cfg.ble_devname, "LED Badge Magic\0\0\0\0", 20);
+	tmos_memcpy(badge_cfg.ble_devname, "LED Badge Magic\0\0\0\0", 20);
 	/* OEM app testing: */
-	// memcpy(badge_cfg.ble_devname, "LSLED\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 20);
+	// tmos_memcpy(badge_cfg.ble_devname, "LSLED\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 20);
 
 	badge_cfg.led_brightness = 0;
 	badge_cfg.led_scan_freq = 2000;
@@ -30,8 +31,10 @@ void cfg_fallback()
 	badge_cfg.splash_speedT = 30; // ms
 
 	int splash_size = ALIGN_1BYTE(splash.w) * splash.h;
-	memset(badge_cfg.splash_bm_bits, 0, sizeof(badge_cfg.splash_bm_bits));
-	memcpy(badge_cfg.splash_bm_bits, splash.bits, splash_size);
+	if (splash_size > (int)sizeof(badge_cfg.splash_bm_bits))
+		splash_size = sizeof(badge_cfg.splash_bm_bits);
+	tmos_memset(badge_cfg.splash_bm_bits, 0, sizeof(badge_cfg.splash_bm_bits));
+	tmos_memcpy(badge_cfg.splash_bm_bits, splash.bits, splash_size);
 	badge_cfg.splash_bm_w = splash.w;
 	badge_cfg.splash_bm_h = splash.h;
 	badge_cfg.splash_bm_fh = splash.fh;

--- a/src/ngctrl.c
+++ b/src/ngctrl.c
@@ -57,6 +57,8 @@ uint8_t power_setting(uint8_t *val, uint16_t len)
 
 static void cfg_ble_devname(uint8_t *name, uint16_t len)
 {
+	if (len > sizeof(badge_cfg.ble_devname))
+		len = sizeof(badge_cfg.ble_devname);
 	tmos_memset(badge_cfg.ble_devname, 0, sizeof(badge_cfg.ble_devname));
 	tmos_memcpy(badge_cfg.ble_devname, name, len);
 }

--- a/src/ngctrl.c
+++ b/src/ngctrl.c
@@ -57,6 +57,7 @@ uint8_t power_setting(uint8_t *val, uint16_t len)
 
 static void cfg_ble_devname(uint8_t *name, uint16_t len)
 {
+	tmos_memset(badge_cfg.ble_devname, 0, sizeof(badge_cfg.ble_devname));
 	tmos_memcpy(badge_cfg.ble_devname, name, len);
 }
 
@@ -106,6 +107,7 @@ uint8_t flash_splash_screen(uint8_t *val, uint16_t len)
 	if (len < 3)
 		return -4;
 
+	tmos_memset(badge_cfg.splash_bm_bits, 0, sizeof(badge_cfg.splash_bm_bits));
 	tmos_memcpy(badge_cfg.splash_bm_bits, &val[3], sz);
 	badge_cfg.splash_bm_w = w;
 	badge_cfg.splash_bm_h = h;


### PR DESCRIPTION
closes #114

When a smaller buffer size is used, the non-overwritten bytes from the old buffer remain in memory, causing a mismatch/garbage data.

fix:
Added a 0 initialization to the buffer before copying the new data over to ensure no old bytes are left behind.

## Summary by Sourcery

Ensure badge configuration buffers are cleared before copying new BLE device name and splash screen bitmap data to prevent stale bytes when shorter payloads are written.

Bug Fixes:
- Zero-initialize BLE device name and splash screen bitmap buffers before copying incoming data to avoid leftover data when new content is shorter than the previous one.

Enhancements:
- Zero out splash screen bitmap buffer during fallback configuration to maintain consistent initialization and prevent residual data.