### PR TITLE
docs: improve ISP entry documentation and clarify C3 shorting method

### DIFF
--- a/CH582.md
+++ b/CH582.md
@@ -63,6 +63,17 @@ Important: Because the badge reassigns the bootloader pin as GPIO after boot,
 it is impossible to switch to bootloader as long as the battery is connected
 to the board (the board is always powered and does not reset). To be able to
 access the bootloader you must then desolder the battery.
+Alternatively, shorting the capacitor C3 while USB is connected can trigger a 
+reset without desoldering or disconnecting the battery. It achieves this as C3 
+is connected to the badge's power rail and briefly shorting it causes a voltage
+drop sufficient to reset the chip, acting as a dirty power cycle. If KEY2 is 
+held at the moment of reset (pulling the BOOT pin LOW), the chip samples the
+BOOT pin as LOW and enters ISP mode. This is less reliable than a clean power
+cycle from battery removal but easier to implement as it does not require soldering.
+
+Note: This method requires shorting C3 specifically using metal tweezers or a 
+wire on a live PCB. Accidentally shorting adjacent components can cause
+permanent damage to the board. Not recommended for beginners.
 
 ## Development Hardware
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,15 @@ the boot pin is pulled down in one of two ways:
 - Disconnect the battery, press and hold KEY2 (the button near the USB port)
   while plugging in the USB to enter the bootloader.
 - Alternatively, connect the USB, press and hold KEY2, then short and release
-  the C3 capacitor.
+  the C3 capacitor using metal tweezers or a wire.
+
+See CH582.md for a technical explanation on why both the above methods work.
 
 If the badge has successfully entered ISP mode, a single pixel roughly in the middle of the display will be lit. The badge will stay in ISP mode for approximately ten seconds before rebooting into normal mode.
 
 On Linux, you can also check `dmesg` if the chip has entered the ISP mode with idVendor=4348 and idProduct=55e0.
+
+Note: The photos shown below for option 2 show two different hardware revisions (Micro-USB and USB-C). C3 is in a different position on each board - Identify your revision before proceeding.
 
 ![c3](assets/burn-badge.svg)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ the boot pin is pulled down in one of two ways:
 - Alternatively, connect the USB, press and hold KEY2, then short and release
   the C3 capacitor using metal tweezers or a wire.
 
-See CH582.md for a technical explanation on why both the above methods work.
+See [CH582.md](CH582.md) for a technical explanation on why both the above methods work.
 
 If the badge has successfully entered ISP mode, a single pixel roughly in the middle of the display will be lit. The badge will stay in ISP mode for approximately ten seconds before rebooting into normal mode.
 


### PR DESCRIPTION
CH582.md explains why battery removal is needed to enter ISP mode but does not explain how the C3 shorting method achieves the same result, leaving readers without context for why it works.

README.md documents the C3 shorting method but does not mention:
- What tool to use (metal tweezers or wire)
- That the two photos show different hardware revisions (Micro USB and USB-C) with C3 in different positions on each board

Changes made:
- CH582.md: 
Added an explanation on how briefly shorting C3 causes a voltage drop on the power rail, acting as a dirty power cycle that resets the chip. Also added warning that accidentally shorting adjacent components on a live PCB can cause permanent board damage.
- README.md: 
Added tool mention (metal tweezers or wire), hardware revision warning, and link to CH582.md for technical details.

Identified while researching for the GSOC 2026 Bootloader Entry Simplification Project.
Closes #134 