### PR TITLE
fix: check return values of malloc in xbm2fb and realloc in cfg_desc_append

### DIFF
--- a/src/usb/setup.c
+++ b/src/usb/setup.c
@@ -1,5 +1,5 @@
 #include <stdlib.h>
-
+#include "../debug.h"
 #include "CH58x_common.h"
 
 #include "utils.h"
@@ -30,7 +30,12 @@ void cfg_desc_append(void *desc)
 		cfg_len = ((USB_CFG_DESCR *)cfg_desc)->wTotalLength;
 	uint8_t newlen = cfg_len + len;
 
-	cfg_desc = realloc(cfg_desc, newlen); // TODO: add a safe check here
+	uint8_t *tmp = realloc(cfg_desc, newlen);
+	if (!tmp) {
+		printf("cfg_desc_append: out of memory\n");
+		return;
+	}
+	cfg_desc = tmp;
 
 	memcpy(cfg_desc + cfg_len, desc, len);
 

--- a/src/xbm.c
+++ b/src/xbm.c
@@ -1,6 +1,7 @@
 #include "xbm.h"
 #include <stdlib.h>
 #include <memory.h>
+#include "debug.h"
 
 /**
  * Draw bitmap file to fb at (col, row)
@@ -9,9 +10,11 @@
 void xbm2fb(xbm_t *xbm, uint16_t *fb, int col, int row)
 {
 	int W = ALIGN_8BIT(xbm->w);
-	uint16_t *tmpfb = malloc(W * sizeof(uint16_t));
-	memset(tmpfb, 0, W * sizeof(uint16_t));
-
+	uint16_t *tmpfb = calloc(W, sizeof(*tmpfb));
+	if (!tmpfb) {
+		printf("xbm2fb: out of memory\n");
+		return;
+	}
 	if ((xbm->h + row) >= 0 && col >= 0) {
 
 		for (int h = 0; h < xbm->h; h++) {


### PR DESCRIPTION
Two unchecked heap allocations fixed:

1. xbm2fb() in xbm.c
   malloc return value was not checked. If allocation fails, the subsequent memset dereferences NULL. xbm2fb() is called every
   frame in the animation loop. Fixed by switching to calloc (which zeroes memory, removing the need for memset) and returning   early if allocation fails.

2. cfg_desc_append() in usb/setup.c
   realloc return value was not checked, with a TODO comment left by the original author acknowledging the missing check. If realloc fails, the original cfg_desc pointer is overwritten with NULL(memory leak) and the subsequent memcpy dereferences NULL. Fixed by storing the result in a temporary pointer, checking for NULL, and only updating cfg_desc on success.

## Summary by Sourcery

Ensure heap allocations in graphics and USB configuration code safely handle allocation failures.

Bug Fixes:
- Handle potential allocation failure in xbm2fb temporary framebuffer allocation to avoid NULL dereference in the animation loop.
- Guard cfg_desc_append against realloc failure to prevent losing the original buffer and dereferencing a NULL pointer.