### PR TITLE
fix: correct DEBUG typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ BUILD_DIR=custom-dir-if-needed make isp
 
 #### Logging over UART
 
-Currently, only the UART1 with baudrate=921600 is used for debuging. To
-enable the log from UART, set the DEUBG=1 when build the project.
+Currently, only the UART1 with baudrate=921600 is used for debugging. To
+enable the log from UART, set the DEBUG=1 when build the project.
 
 Any USB to UART dongle will work. Use your favorite terminal emulator to see the
 log, e.g.:


### PR DESCRIPTION
Fixes #135 

- Corrected `DEUBG=1` to `DEBUG=1`
- Fixed spelling: `debuging` → `debugging`

## Summary by Sourcery

Documentation:
- Fix README to use the correct DEBUG=1 flag and fix spelling in the UART debugging section.