### PR TITLE
docs(readme): fix debugging-section typos (DEUBG, debuging)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ BUILD_DIR=custom-dir-if-needed make isp
 #### Logging over UART
 
 Currently, only the UART1 with baudrate=921600 is used for debugging. To
-enable the log from UART, set the DEBUG=1 when build the project.
+enable the log from UART, set the DEBUG=1 when building the project.
 
 Any USB to UART dongle will work. Use your favorite terminal emulator to see the
 log, e.g.:

--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ BUILD_DIR=custom-dir-if-needed make isp
 
 #### Logging over UART
 
-Currently, only the UART1 with baudrate=921600 is used for debuging. To
-enable the log from UART, set the DEUBG=1 when build the project.
+Currently, only the UART1 with baudrate=921600 is used for debugging. To
+enable the log from UART, set the DEBUG=1 when build the project.
 
 Any USB to UART dongle will work. Use your favorite terminal emulator to see the
 log, e.g.:


### PR DESCRIPTION
Fixes #135. Two typos in the debugging section of README.

```diff
- used for debuging. To enable the log from UART, set the DEUBG=1
+ used for debugging. To enable the log from UART, set the DEBUG=1
```

Single file, README-only.

## Summary by Sourcery

Documentation:
- Correct spelling and the DEBUG flag name in the README UART logging section.