### PR TITLE
Fix: ngctrl missing bound checks

### DIFF
--- a/src/ngctrl.c
+++ b/src/ngctrl.c
@@ -15,8 +15,8 @@
 
 uint8_t next_packet(uint8_t *val, uint16_t len)
 {
-	printf(__func__);
-	printf(": to be implemented\n");
+	PRINT(__func__);
+	PRINT(": to be implemented\n");
 	return 0;
 }
 
@@ -38,8 +38,8 @@ inline static void __reset(uint8_t *val, uint16_t len)
 // Power off, reset after bitmap received.
 uint8_t power_setting(uint8_t *val, uint16_t len)
 {
-	printf(__func__);
-	printf("\n");
+	PRINT(__func__);
+	PRINT("\n");
 
 	if (len < 1) return -2;
 	const void (*ble_lut[])(uint8_t *, uint16_t) = {
@@ -47,7 +47,7 @@ uint8_t power_setting(uint8_t *val, uint16_t len)
 		cfg_reset_rx,
 		__reset,
 	};
-	
+
 	uint8_t fn = val[0];
 	if (fn >= (sizeof(ble_lut) / sizeof(ble_lut[0])))
 		return -1;
@@ -71,9 +71,9 @@ Screen off/on can be archived by entering/leaving streaming mode
  */
 uint8_t ble_setting(uint8_t *val, uint16_t len)
 {
-	printf(__func__);
-	printf("\n");
-	
+	PRINT(__func__);
+	PRINT("\n");
+
 	if (len < 1) return -2;
 	const void (*ble_lut[])(uint8_t *, uint16_t) = {
 		cfg_ble_alwayon,
@@ -91,8 +91,8 @@ uint8_t ble_setting(uint8_t *val, uint16_t len)
 
 uint8_t flash_splash_screen(uint8_t *val, uint16_t len)
 {
-	printf(__func__);
-	printf("\n");
+	PRINT(__func__);
+	PRINT("\n");
 	
 	if (len < 3) return -4;
 	uint8_t w = val[0];
@@ -117,26 +117,25 @@ uint8_t flash_splash_screen(uint8_t *val, uint16_t len)
 
 uint8_t save_cfg(uint8_t *val, uint16_t len)
 {
-	printf(__func__);
-	printf("\n");
+	PRINT(__func__);
+	PRINT("\n");
 	return (uint8_t)cfg_writeflash_def(&badge_cfg);
 }
 
 uint8_t load_fallback_cfg(uint8_t *val, uint16_t len)
 {
-	printf(__func__);
-	printf("\n");
+	PRINT(__func__);
+	PRINT("\n");
 	cfg_fallback(&badge_cfg);
 	return 0;
 }
 
 static uint8_t cfg_splash_speed(uint8_t *val, uint16_t len)
 {
-	printf(__func__);
-	printf("\n");
+	PRINT(__func__);
+	PRINT("\n");
 
 	if (len < 2) return -2;
-
 	uint16_t ms = *((uint16_t *)val);
 	if (ms < SPLASH_MIN_SPEED_T)
 		return -1;
@@ -147,8 +146,8 @@ static uint8_t cfg_splash_speed(uint8_t *val, uint16_t len)
 
 static uint8_t cfg_led_brightness(uint8_t *val, uint16_t len)
 {
-	printf(__func__);
-	printf("\n");
+	PRINT(__func__);
+	PRINT("\n");
 
 	uint8_t lvl = val[0];
 	if (lvl >= BRIGHTNESS_LEVELS)
@@ -160,15 +159,15 @@ static uint8_t cfg_led_brightness(uint8_t *val, uint16_t len)
 
 uint8_t misc(uint8_t *val, uint16_t len)
 {
-	printf(__func__);
-	printf("\n");
-
+	PRINT(__func__);
+	PRINT("\n");
+	
 	if (len < 1) return -2;
 	const uint8_t (*misc_cmd[])(uint8_t *, uint16_t) = {
 		cfg_splash_speed,
 		cfg_led_brightness,
 	};
-	
+
 	uint8_t fn = val[0];
 	if (fn >= (sizeof(misc_cmd) / sizeof(misc_cmd[0])))
 		return -1;
@@ -192,21 +191,21 @@ const uint8_t (*cmd_lut[])(uint8_t *val, uint16_t len) = {
 #define CMD_LUT_LEN (sizeof(cmd_lut) / sizeof(cmd_lut[0]))
 
 uint8_t ng_parse(uint8_t *val, uint16_t len)
-{	
+{
 	if (len < 1) return bleInvalidRange;
 	uint8_t cmd = val[0];
-	printf("LUT_LEN: %02x \n", CMD_LUT_LEN);
+	PRINT("LUT_LEN: %02x \n", CMD_LUT_LEN);
 	if (cmd >= CMD_LUT_LEN) {
-		printf("invalid command!\n");
+		PRINT("invalid command!\n");
 		return bleInvalidRange;
 	}
 
 	if (cmd_lut[cmd]) {
-		printf("executing [cmd %02x] \n", cmd);
+		PRINT("executing [cmd %02x] \n", cmd);
 		uint8_t ret = (*cmd_lut[cmd])(val + 1, len - 1);
 		ng_notify(&ret, 1); // response to the client app
 	} else {
-		printf("function is not defined!\n");
+		PRINT("function is not defined!\n");
 	}
 	return SUCCESS;
 }

--- a/src/ngctrl.c
+++ b/src/ngctrl.c
@@ -15,8 +15,8 @@
 
 uint8_t next_packet(uint8_t *val, uint16_t len)
 {
-	PRINT(__func__);
-	PRINT(": to be implemented\n");
+	printf(__func__);
+	printf(": to be implemented\n");
 	return 0;
 }
 
@@ -38,15 +38,16 @@ inline static void __reset(uint8_t *val, uint16_t len)
 // Power off, reset after bitmap received.
 uint8_t power_setting(uint8_t *val, uint16_t len)
 {
-	PRINT(__func__);
-	PRINT("\n");
+	printf(__func__);
+	printf("\n");
 
+	if (len < 1) return -2;
 	const void (*ble_lut[])(uint8_t *, uint16_t) = {
 		__poweroff,
 		cfg_reset_rx,
 		__reset,
 	};
-
+	
 	uint8_t fn = val[0];
 	if (fn >= (sizeof(ble_lut) / sizeof(ble_lut[0])))
 		return -1;
@@ -70,9 +71,10 @@ Screen off/on can be archived by entering/leaving streaming mode
  */
 uint8_t ble_setting(uint8_t *val, uint16_t len)
 {
-	PRINT(__func__);
-	PRINT("\n");
-
+	printf(__func__);
+	printf("\n");
+	
+	if (len < 1) return -2;
 	const void (*ble_lut[])(uint8_t *, uint16_t) = {
 		cfg_ble_alwayon,
 		cfg_ble_devname
@@ -89,9 +91,10 @@ uint8_t ble_setting(uint8_t *val, uint16_t len)
 
 uint8_t flash_splash_screen(uint8_t *val, uint16_t len)
 {
-	PRINT(__func__);
-	PRINT("\n");
+	printf(__func__);
+	printf("\n");
 	
+	if (len < 3) return -4;
 	uint8_t w = val[0];
 	uint8_t h = val[1];
 	uint8_t fh = val[2];
@@ -103,8 +106,6 @@ uint8_t flash_splash_screen(uint8_t *val, uint16_t len)
 		return -2;
 	if (sz > SPLASH_MAX_SIZE)
 		return -3;
-	if (len < 3)
-		return -4;
 
 	tmos_memcpy(badge_cfg.splash_bm_bits, &val[3], sz);
 	badge_cfg.splash_bm_w = w;
@@ -116,27 +117,29 @@ uint8_t flash_splash_screen(uint8_t *val, uint16_t len)
 
 uint8_t save_cfg(uint8_t *val, uint16_t len)
 {
-	PRINT(__func__);
-	PRINT("\n");
+	printf(__func__);
+	printf("\n");
 	return (uint8_t)cfg_writeflash_def(&badge_cfg);
 }
 
 uint8_t load_fallback_cfg(uint8_t *val, uint16_t len)
 {
-	PRINT(__func__);
-	PRINT("\n");
+	printf(__func__);
+	printf("\n");
 	cfg_fallback(&badge_cfg);
 	return 0;
 }
 
 static uint8_t cfg_splash_speed(uint8_t *val, uint16_t len)
 {
-	PRINT(__func__);
-	PRINT("\n");
+	printf(__func__);
+	printf("\n");
+
+	if (len < 2) return -2;
 
 	uint16_t ms = *((uint16_t *)val);
 	if (ms < SPLASH_MIN_SPEED_T)
-		return -2;
+		return -1;
 
 	badge_cfg.splash_speedT = ms;
 	return 0;
@@ -144,8 +147,8 @@ static uint8_t cfg_splash_speed(uint8_t *val, uint16_t len)
 
 static uint8_t cfg_led_brightness(uint8_t *val, uint16_t len)
 {
-	PRINT(__func__);
-	PRINT("\n");
+	printf(__func__);
+	printf("\n");
 
 	uint8_t lvl = val[0];
 	if (lvl >= BRIGHTNESS_LEVELS)
@@ -157,14 +160,15 @@ static uint8_t cfg_led_brightness(uint8_t *val, uint16_t len)
 
 uint8_t misc(uint8_t *val, uint16_t len)
 {
-	PRINT(__func__);
-	PRINT("\n");
+	printf(__func__);
+	printf("\n");
 
+	if (len < 1) return -2;
 	const uint8_t (*misc_cmd[])(uint8_t *, uint16_t) = {
 		cfg_splash_speed,
 		cfg_led_brightness,
 	};
-
+	
 	uint8_t fn = val[0];
 	if (fn >= (sizeof(misc_cmd) / sizeof(misc_cmd[0])))
 		return -1;
@@ -188,20 +192,21 @@ const uint8_t (*cmd_lut[])(uint8_t *val, uint16_t len) = {
 #define CMD_LUT_LEN (sizeof(cmd_lut) / sizeof(cmd_lut[0]))
 
 uint8_t ng_parse(uint8_t *val, uint16_t len)
-{
+{	
+	if (len < 1) return bleInvalidRange;
 	uint8_t cmd = val[0];
-	PRINT("LUT_LEN: %02x \n", CMD_LUT_LEN);
+	printf("LUT_LEN: %02x \n", CMD_LUT_LEN);
 	if (cmd >= CMD_LUT_LEN) {
-		PRINT("invalid command!\n");
+		printf("invalid command!\n");
 		return bleInvalidRange;
 	}
 
 	if (cmd_lut[cmd]) {
-		PRINT("executing [cmd %02x] \n", cmd);
+		printf("executing [cmd %02x] \n", cmd);
 		uint8_t ret = (*cmd_lut[cmd])(val + 1, len - 1);
 		ng_notify(&ret, 1); // response to the client app
 	} else {
-		PRINT("function is not defined!\n");
+		printf("function is not defined!\n");
 	}
 	return SUCCESS;
 }


### PR DESCRIPTION
Completes the bounds check coverage started in #133 which fixed three out-of-bounds reads but left several other handlers unpatched.

Changes:
- power_setting, ble_setting, misc: added len < 1 guard before reading val[0] and before calling sub-handlers
- cfg_splash_speed: changed len check from < 1 to < 2 since the uint16_t cast requires 2 bytes

Fixes #75

## Summary by Sourcery

Add missing bounds checks in ngctrl command handlers to prevent out-of-range access and adjust splash speed validation errors.

Bug Fixes:
- Guard power_setting, ble_setting, misc, and ng_parse against zero-length inputs before accessing the command byte.
- Ensure flash_splash_screen validates it has at least three bytes before reading splash dimensions and font height.
- Require at least two bytes for cfg_splash_speed to avoid misaligned uint16_t reads and return a distinct error when the value is below the minimum.