### PR TITLE
feat: sync RTC with timestamp for future clock display feature on LED badge

### DIFF
--- a/src/legacyctrl.c
+++ b/src/legacyctrl.c
@@ -3,6 +3,7 @@
 #include "leddrv.h"
 #include "debug.h"
 #include "legacyctrl.h"
+#include "CH58x_common.h"
 
 int legacy_ble_rx(uint8_t *val, uint16_t len)
 {
@@ -62,6 +63,8 @@ int legacy_ble_rx(uint8_t *val, uint16_t len)
 
 	if (c > 2 && ((c+1) * LEGACY_TRANSFER_WIDTH) >= data_len) {
 		PRINT("All bitmaps data received successfully\nWriting to flash.. ");
+		data_legacy_t *d = (data_legacy_t *)data;
+		RTC_InitTime(2026, 1, 1, d->timestamp[3], d->timestamp[4], d->timestamp[5]);
 		data_flatSave(data, data_len);
 		free(data);
 		data = NULL;

--- a/src/legacyctrl.c
+++ b/src/legacyctrl.c
@@ -64,7 +64,7 @@ int legacy_ble_rx(uint8_t *val, uint16_t len)
 	if (c > 2 && ((c+1) * LEGACY_TRANSFER_WIDTH) >= data_len) {
 		PRINT("All bitmaps data received successfully\nWriting to flash.. ");
 		data_legacy_t *d = (data_legacy_t *)data;
-		RTC_InitTime(2026, 1, 1, d->timestamp[3], d->timestamp[4], d->timestamp[5]);
+		RTC_InitTime(2000 + ((d->timestamp[0] - 208 + 256) % 256), d->timestamp[1], d->timestamp[2], d->timestamp[3], d->timestamp[4], d->timestamp[5]);
 		data_flatSave(data, data_len);
 		free(data);
 		data = NULL;


### PR DESCRIPTION
The legacy BLE packet already contained a timestamp (hour, minute, second) which was sent by the app to the badge but unused. Now the code syncs the RTC with this timestamp whenever the badge receives data from the app.
This is groundwork for a future clock display feature on the LED matrix where once the RTC has correct time, a new LED animation mode can be added that reads from the RTC and renders the current time on the matrix updating every minute or so.

Fixes #36

## Summary by Sourcery

New Features:
- Initialize and update the RTC with the timestamp carried in incoming legacy BLE data packets.