### PR TITLE
add unified error codes (error.h)

### DIFF
--- a/src/error.h
+++ b/src/error.h
@@ -1,0 +1,22 @@
+#ifndef __ERROR_H__
+#define __ERROR_H__
+
+typedef enum {
+    BM_OK               = 0,
+    BM_ERR_TOO_SHORT    = 1,
+    BM_ERR_INVALID_CMD  = 2,
+    BM_ERR_NOT_IMPL     = 3,
+    BM_ERR_NO_MEM       = 4,
+    BM_ERR_OUT_OF_RANGE = 5,
+    BM_ERR_INVALID_SIZE = 6,
+    BM_ERR_BAD_HEADER   = 7,
+    BM_ERR_FLASH        = 8,
+} bm_err_t;
+
+typedef enum {
+    BM_USB_OK           =  0,
+    BM_USB_ERR_TIMEOUT  = -1,
+    BM_USB_ERR_NO_MEM   = -2,
+} bm_usb_err_t;
+
+#endif 


### PR DESCRIPTION
Closes #76 (only the error codes part, not logging)
Error codes across the codebase are inconsistent and chaotic which can lead to confusion and is not user friendly.
ngctrl.c, legacyctrl.c and usb/files all use raw -1,-2,-3,-4 with no shared meaning.

This PR adds src/error.h with two enums:
- bm_err_t - for command/app layer (ngctrl, legacyctrl, config)
- bm_usb_err_t - for USB/transport layer (usb/hiddev, usb/cdc-serial, usb/utils)

Follow-up needed: (Once approved, all the affected files can be modified accordingly)
- Replace all raw magic number returns with named enum values
- Fix ngctrl.c signatures from uint8_t to bm_err_t
- Keep BLE stack codes (bleInvalidRange, SUCCESS) only in ng_parse() and not in internal functions

## Summary by Sourcery

Introduce centralized error code definitions for application and USB layers

New Features:
- Add bm_err_t enum for standardized application-level error codes
- Add bm_usb_err_t enum for standardized USB/transport-level error codes