### PR TITLE
Added clock display feature which is toggled by KEY3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ src/resource.c \
 src/animation.c \
 src/font.c \
 src/power.c \
+src/auxbtn.c \
 
 
 # ASM sources

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ CFLAGS += -DUSBC_VERSION=$(USBC_VERSION)
 endif
 
 CFLAGS += -DVERSION='"$(VERSION)"' -DVERSION_ABBR='"$(VERSION_ABBR)"'
+CFLAGS += -DCLK_OSC32K=2
 
 # Generate dependency information
 CFLAGS += -MMD -MP

--- a/src/auxbtn.c
+++ b/src/auxbtn.c
@@ -1,0 +1,143 @@
+#include "CH58x_common.h"
+#include "CH58xBLE_LIB.h"
+#include <stdbool.h>
+#include "auxbtn.h"
+#include "debug.h"
+#include "usb/usb.h"
+
+#define AUX_ADC_CHANNEL         (3)
+#define BATT_ADC_CHANNEL        (1)
+#define ADC_SAMPLE_COUNT        (20)
+
+#define NO_PRESS_LOW            (3601)
+#define KEY3_HIGH               (500)
+#define KEY4_LOW                (3300)
+#define KEY4_HIGH               (3600)
+#define DEBOUNCE_THRES          (5)
+
+enum aux_state {
+    AUX_NO_PRESS = 0,
+    AUX_KEY3,
+    AUX_KEY4,
+    AUX_UNDEFINED,
+};
+
+static volatile void (*onePressHandler[2])(void) = { NULL };
+static volatile bool onePressPending[2] = { false };
+
+static tmosTaskID auxbtn_task_id = INVALID_TASK_ID;
+#define AUXBTN_POLL (1 << 0)
+#define AUXBTN_POLL_FREQ (50) //same as button.c
+
+static int aux_adc_read()
+{
+    ADC_ChannelCfg(AUX_ADC_CHANNEL);
+
+    int ret = 0;
+    for (int i = 0; i < ADC_SAMPLE_COUNT; i++) {
+        ret += ADC_ExcutSingleConver();
+    }
+
+    ADC_ChannelCfg(BATT_ADC_CHANNEL);
+    ret = ret / ADC_SAMPLE_COUNT;
+
+    char buf[32];
+    int len = snprintf(buf, sizeof(buf), "ADC: %d\n", ret);
+    cdc_tx_poll((uint8_t *)buf, len, 10);
+
+    return ret;
+}
+
+static enum aux_state classify(int raw)
+{
+    if (raw > NO_PRESS_LOW)
+        return AUX_NO_PRESS;
+    if (raw < KEY3_HIGH)
+        return AUX_KEY3;
+    if (raw > KEY4_LOW && raw < KEY4_HIGH)
+        return AUX_KEY4;
+    return AUX_UNDEFINED;
+}
+
+static void auxbtn_poll()
+{
+    static enum aux_state last = AUX_NO_PRESS;
+    static int count = 0;
+
+    enum aux_state curr = classify(aux_adc_read());
+
+    if (curr == AUX_UNDEFINED) {
+        count = 0;
+        return;
+    }
+
+    if (curr == AUX_NO_PRESS) {
+        last = AUX_NO_PRESS;
+        count = 0;
+        return;
+    }
+
+    if (curr == last) {
+        count++;
+    } else {
+        last = curr;
+        count = 1;
+        return;
+    }
+
+    if (count == DEBOUNCE_THRES) {
+        if (curr == AUX_KEY3)
+            onePressPending[0] = true;
+        else if (curr == AUX_KEY4)
+            onePressPending[1] = true;
+    }
+}
+
+static void auxbtn_tick()
+{
+    for (int i = 0; i < 2; i++) {
+        if (onePressPending[i]) {
+            onePressPending[i] = false;
+            if (onePressHandler[i])
+                onePressHandler[i]();
+        }
+    }
+}
+
+static uint16_t auxbtn_task(tmosTaskID id, uint16_t events)
+{
+    if (events & SYS_EVENT_MSG) {
+        uint8 *pMsg = tmos_msg_receive(auxbtn_task_id);
+        if (pMsg != NULL)
+            tmos_msg_deallocate(pMsg);
+        return (events ^ SYS_EVENT_MSG);
+    }
+
+    if (events & AUXBTN_POLL) {
+        auxbtn_poll();
+        auxbtn_tick();
+        return (events ^ AUXBTN_POLL);
+    }
+
+    return events;
+}
+
+void auxbtn_init_task(void)
+{
+    auxbtn_task_id = TMOS_ProcessEventRegister(auxbtn_task);
+    tmos_start_reload_task(auxbtn_task_id, AUXBTN_POLL,
+                1000000 / AUXBTN_POLL_FREQ / 625);
+}
+
+void auxbtn_init(void)
+{
+    GPIOA_ModeCfg(GPIO_Pin_13, GPIO_ModeIN_Floating);
+}
+
+void auxbtn_onOnePress(int key, void (*handler)(void))
+{
+    if (key == KEY3)
+        onePressHandler[0] = handler;
+    else if (key == KEY4)
+        onePressHandler[1] = handler;
+}

--- a/src/auxbtn.h
+++ b/src/auxbtn.h
@@ -1,0 +1,10 @@
+#ifndef AUXBTN_H
+#define AUXBTN_H
+
+#include "button.h"
+
+void auxbtn_init(void);
+void auxbtn_init_task(void);
+void auxbtn_onOnePress(int key, void (*handler)(void));
+
+#endif 

--- a/src/ble/setup.c
+++ b/src/ble/setup.c
@@ -71,7 +71,7 @@ void ble_hardwareInit(void)
 	cfg.TxPower = (uint32_t)BLE_TX_POWER;
 	cfg.ConnectNumber = (PERIPHERAL_MAX_CONNECTION & 3) | (CENTRAL_MAX_CONNECTION << 2);
 
-	cfg.SelRTCClock = 1 << 7;
+	cfg.SelRTCClock = (1 << 7) | 0x02;
 
 	cfg.rcCB = lsi_calib;
 

--- a/src/button.h
+++ b/src/button.h
@@ -6,6 +6,8 @@
 enum keys {
 	KEY1 = 0,
 	KEY2,
+	KEY3,
+	KEY4,
 	KEY_INDEX,
 };
 

--- a/src/main.c
+++ b/src/main.c
@@ -454,7 +454,8 @@ void handle_after_rx()
 int main()
 {
 	SetSysClock(CLK_SOURCE_PLL_60MHz);
-
+	Calibration_LSI(Level_128);
+	
 	debug_init();
 	PRINT("\nDebug console is on UART%d\n", DEBUG);
 

--- a/src/main.c
+++ b/src/main.c
@@ -443,7 +443,11 @@ void handle_after_rx()
 	if (badge_cfg.reset_rx) {
 		SYS_ResetExecute();
 	} else {
-		mode_setup_normal();
+		if (clock_active) {
+            clock_active = 0;
+            tmos_stop_task(common_taskid, CLOCK_TICK);
+        }
+        mode_setup_normal();
 	}
 }
 
@@ -491,6 +495,7 @@ int main()
 
 	spawn_tasks();
 	btn_init_task();
+	auxbtn_init_task();
 
 	mode = NORMAL;
 	while (1) {

--- a/src/main.c
+++ b/src/main.c
@@ -46,11 +46,13 @@ enum MODES {
 #define ANI_FLASH           (1 << 2)
 #define SCAN_BOOTLD_BTN     (1 << 3)
 #define BLE_NEXT_STEP       (1 << 4)
+#define CLOCK_TICK          (1 << 5)
 
 static tmosTaskID common_taskid = INVALID_TASK_ID ;
 
 volatile uint16_t fb[LED_COLS] = {0};
 volatile int mode, is_play_sequentially = 1;
+static int clock_active = 0;
 
 __HIGH_CODE
 static void change_brightness()
@@ -207,6 +209,11 @@ static uint16_t common_tasks(tmosTaskID task_id, uint16_t events)
 
 		return events ^ BLE_NEXT_STEP;
 	}
+	
+	if (events & CLOCK_TICK) {
+		disp_clock();
+		return events ^ CLOCK_TICK;
+	}
 
 	return 0;
 }
@@ -340,6 +347,24 @@ static void fb_puts(char *s, int len, int col, int row)
 	}
 }
 
+static void disp_clock()
+{
+    uint16_t year;
+    uint8_t month, day, hour, minute, second;
+    RTC_GetTime(&year, &month, &day, &hour, &minute, &second);
+    memset(fb, 0, sizeof(fb));
+
+    char buf[6];
+    buf[0] = '0' + hour / 10;
+    buf[1] = '0' + hour % 10;
+    buf[2] = ':';
+    buf[3] = '0' + minute / 10;
+    buf[4] = '0' + minute % 10;
+    buf[5] = '\0';
+
+    fb_puts(buf, 5, 2, 2);
+}
+
 static void disp_charging()
 {
 	int blink = 0;
@@ -399,6 +424,19 @@ static void mode_setup_normal()
 	start_normal_animation();
 }
 
+static void toggle_clock()
+{
+    if (!clock_active) {
+        clock_active = 1;
+        stop_all_animation();
+        tmos_start_reload_task(common_taskid, CLOCK_TICK, 1000000 / 625);
+    } else {
+        clock_active = 0;
+        tmos_stop_task(common_taskid, CLOCK_TICK);
+        mode_setup_normal();
+    }
+}
+
 void handle_after_rx()
 {
 	if (badge_cfg.reset_rx) {
@@ -430,6 +468,10 @@ int main()
 	btn_onOnePress(KEY1, change_mode);
 	btn_onOnePress(KEY2, bm_transition);
 	btn_onLongPress(KEY1, change_brightness);
+
+	auxbtn_init();
+	auxbtn_onOnePress(KEY3, toggle_clock);
+	auxbtn_onOnePress(KEY4, bm_transition);
 
 	power_init();
 	disp_charging();

--- a/src/main.c
+++ b/src/main.c
@@ -454,7 +454,6 @@ void handle_after_rx()
 int main()
 {
 	SetSysClock(CLK_SOURCE_PLL_60MHz);
-	Calibration_LSI(Level_128);
 	
 	debug_init();
 	PRINT("\nDebug console is on UART%d\n", DEBUG);

--- a/src/main.c
+++ b/src/main.c
@@ -8,6 +8,7 @@
 #include "resource.h"
 #include "animation.h"
 #include "font.h"
+#include "auxbtn.h"
 
 #include "power.h"
 #include "data.h"
@@ -62,6 +63,7 @@ static void change_brightness()
 
 static void mode_setup_download();
 static void mode_setup_normal();
+static void disp_clock();
 
 __HIGH_CODE
 static void change_mode()
@@ -349,8 +351,7 @@ static void fb_puts(char *s, int len, int col, int row)
 
 static void disp_clock()
 {
-    uint16_t year;
-    uint8_t month, day, hour, minute, second;
+    uint16_t year, month, day, hour, minute, second;
     RTC_GetTime(&year, &month, &day, &hour, &minute, &second);
     memset(fb, 0, sizeof(fb));
 

--- a/src/power.c
+++ b/src/power.c
@@ -24,6 +24,7 @@ void poweroff()
 
 void power_init()
 {
+	Calibration_LSI(Level_128);
 	GPIOA_ModeCfg(GPIO_Pin_5, GPIO_ModeIN_Floating);
 	ADC_ExtSingleChSampInit(SampleFreq_3_2, ADC_PGA_0);
 

--- a/src/power.c
+++ b/src/power.c
@@ -24,7 +24,6 @@ void poweroff()
 
 void power_init()
 {
-	Calibration_LSI(Level_128);
 	GPIOA_ModeCfg(GPIO_Pin_5, GPIO_ModeIN_Floating);
 	ADC_ExtSingleChSampInit(SampleFreq_3_2, ADC_PGA_0);
 


### PR DESCRIPTION
Fixes #145 
This PR implements a clock display feature on the LED matrix, building on the RTC sync groundwork from #142

About the new feature:
- Pressing KEY3 toggles clock mode on/off independently of KEY1
- In clock mode, the current time is read from the RTC and displayed as HH:MM on the LED matrix
- The display updates every second via a TMOS reload task
- Pressing KEY3 again exits clock mode and resumes normal bitmap animation
- Clock accuracy depends on RTC being synced and time is set whenever a bitmap is received from the BadgeMagic app

The clock feature is now working and has been tested on the badge, however as there is no external crystal on the board we cannot use LSE and must stick to LSI. Due to this, there is a drift of approx. 2-3s every min which isn't a good thing. I got it down to this by using LSI_Calibration with the system clock as it was initially some 10s/min of drift. If we keep sending bitmap data frequently the time will be synced but that is very illogical.
If anyone has any solutions pls let me know.

## Summary by Sourcery

Add a toggleable clock display mode driven by KEY3 that shows the current time on the LED matrix and updates once per second.

New Features:
- Introduce a clock display mode that renders the current HH:MM time on the LED matrix using RTC data.
- Enable toggling of clock mode on and off via KEY3 independently of existing animation controls.
- Add auxiliary button handling for KEY3 and KEY4 to support clock toggling and bitmap transitions.

Enhancements:
- Integrate a periodic CLOCK_TICK task into the common task loop to refresh the clock display at a fixed interval.