### PR TITLE
docs(CH582): fix 'seperately' -> 'separately'

### DIFF
--- a/CH582.md
+++ b/CH582.md
@@ -80,4 +80,4 @@ access the bootloader you must then desolder the battery.
   
   * Moonriver toolchain contains an older xpack and a custom openocd.
 
-  * The more recent xpack toolchain changes using `riscv-none-elf-` as PREFIX in the Makefile instead of `riscv-none-embed-`. This target also requires to activate extensions seperately by setting `-march=rv32imac_zicsr` instead of `-march=rv32imac`
+  * The more recent xpack toolchain changes using `riscv-none-elf-` as PREFIX in the Makefile instead of `riscv-none-embed-`. This target also requires to activate extensions separately by setting `-march=rv32imac_zicsr` instead of `-march=rv32imac`


### PR DESCRIPTION
## Summary
Single-word typo fix in `CH582.md` line 83 (xpack toolchain note):

```diff
- requires to activate extensions seperately by setting
+ requires to activate extensions separately by setting
```

## Verification
- `grep -n seperately CH582.md` → no matches after the change.

## Note
Co-developed with AI assistance; reviewed and tested by submitter.

## Summary by Sourcery

Documentation:
- Correct a typo in CH582.md where 'seperately' is updated to 'separately' in the xpack toolchain note.