### PR TITLE
fix: clipart alignment issue

### DIFF
--- a/src/animation.c
+++ b/src/animation.c
@@ -275,6 +275,26 @@ static void still(bm_t *bm, uint16_t *fb, int frame)
 	}
 }
 
+static void still_centered(bm_t *bm, uint16_t *fb, int frame)
+{
+	// How many columns does this frame actually occupy?
+	int frame_start = frame * LED_COLS;
+	int frame_width = bm->width - frame_start;
+	if (frame_width > LED_COLS)
+		frame_width = LED_COLS;
+
+	// Center that content within the LED_COLS-wide framebuffer
+	int offset = (LED_COLS - frame_width) / 2;
+
+	// Clear the whole framebuffer first
+	for (int j = 0; j < LED_COLS; j++)
+		fb[j] = 0;
+
+	// Copy content starting at the centered offset 
+	for (int j = 0; j < frame_width; j++)
+		fb[offset + j] = bm->buf[frame_start + j];
+}
+
 int ani_laser(bm_t *bm, uint16_t *fb)
 {
 	int frame_steps = LED_COLS * 3; // in-still-out
@@ -395,7 +415,7 @@ int ani_fixed(bm_t *bm, uint16_t *fb)
 	int frame = mod(bm->anim_step, total_steps)/frame_steps;
 
 	bm->anim_step++;
-	still(bm, fb, frame);
+	still_centered(bm, fb, frame);
 
 	return mod(bm->anim_step, total_steps);
 }

--- a/src/data.c
+++ b/src/data.c
@@ -49,24 +49,29 @@ uint16_t data_flash2newmem(uint8_t **chunk, uint32_t n)
 	return size;
 }
 
-static void __chunk2buffer(uint16_t *bm, uint8_t *chunk, int col) 
+static void __chunk2buffer(uint16_t *bm, uint8_t *chunk, int col, int max_col) 
 {
-	uint16_t tmpbm[8] = {0};
-	for (int i=0; i<8; i++) {
-		for (int j=0; j<11; j++) {
-			tmpbm[i] |= ((chunk[j] >> (7-i)) & 0x01) << j;
-		}
-	}
-	for (int i=0; i<8; i++) {
-		bm[col+i] = tmpbm[i];
-	}
+    uint16_t tmpbm[8] = {0};
+    for (int i=0; i<8; i++) {
+        for (int j=0; j<11; j++) {
+            tmpbm[i] |= ((chunk[j] >> (7-i)) & 0x01) << j;
+        }
+    }
+    for (int i=0; i<8 && (col+i) < max_col; i++) {
+        bm[col+i] = tmpbm[i];
+    }
 }
 
 void chunk2buffer(uint8_t *chunk, uint16_t size, uint16_t *buf)
 {
-	for (int i=0; i<size/11; i++) {
-		__chunk2buffer(buf, &chunk[i*11], 8 * i);
-	}
+    int chunks_per_row = 6; 
+    for (int i = 0; i < size/11; i++) {
+        int frame = i / chunks_per_row;
+        int col_in_frame = (i % chunks_per_row) * 8;
+        __chunk2buffer(buf, &chunk[i*11],
+                       frame * LED_COLS + col_in_frame,
+                       (frame+1) * LED_COLS);
+    }
 }
 
 void chunk2bm(uint8_t *chunk, uint16_t size, bm_t *bm)

--- a/src/data.c
+++ b/src/data.c
@@ -66,8 +66,8 @@ void chunk2buffer(uint8_t *chunk, uint16_t size, uint16_t *buf)
 {
 	int num_chunks = size / 11;
 	for (int i = 0; i < num_chunks; i++) {
-		int frame = i / CHUNKS_PER_ROW;
-		int col_in_frame = (i % CHUNKS_PER_ROW) * 8;
+		int frame = i / 6;
+		int col_in_frame = (i % 6) * 8;
 		__chunk2buffer(buf, &chunk[i*11], frame * LED_COLS + col_in_frame, (frame+1) * LED_COLS);
 	}
 }

--- a/src/data.c
+++ b/src/data.c
@@ -64,14 +64,12 @@ static void __chunk2buffer(uint16_t *bm, uint8_t *chunk, int col, int max_col)
 
 void chunk2buffer(uint8_t *chunk, uint16_t size, uint16_t *buf)
 {
-    int chunks_per_row = 6; 
-    for (int i = 0; i < size/11; i++) {
-        int frame = i / chunks_per_row;
-        int col_in_frame = (i % chunks_per_row) * 8;
-        __chunk2buffer(buf, &chunk[i*11],
-                       frame * LED_COLS + col_in_frame,
-                       (frame+1) * LED_COLS);
-    }
+	int num_chunks = size / 11;
+	for (int i = 0; i < num_chunks; i++) {
+		int frame = i / CHUNKS_PER_ROW;
+		int col_in_frame = (i % CHUNKS_PER_ROW) * 8;
+		__chunk2buffer(buf, &chunk[i*11], frame * LED_COLS + col_in_frame, (frame+1) * LED_COLS);
+	}
 }
 
 void chunk2bm(uint8_t *chunk, uint16_t size, bm_t *bm)
@@ -81,7 +79,10 @@ void chunk2bm(uint8_t *chunk, uint16_t size, bm_t *bm)
 
 bm_t *chunk2newbm(uint8_t *chunk, uint16_t size)
 {
-	bm_t *bm = bm_new((size*8)/11);
+	int num_chunks = size / 11;
+	int frames = (num_chunks + 5) / 6;
+
+	bm_t *bm = bm_new(frames * LED_COLS);
 	chunk2bm(chunk, size, bm);
 	return bm;
 }


### PR DESCRIPTION
Fixes https://github.com/fossasia/badgemagic-app/issues/1557
chunk2buffer packed clipart data in fixed 8-column chunks, but ani_fixed reads frames as LED_COLS (44) wide. Since 44 is not a
multiple of 8, frame boundaries didn't align with chunk boundaries causing a 2-4 column rightward shift on clipart fixed display.

## Summary by Sourcery

Bug Fixes:
- Prevent clipart frames from being horizontally shifted due to misaligned chunk-to-buffer column mapping across non-multiple-of-eight display widths.