### PR TITLE
fix: restore KEY3/KEY4 controls for clock submenu and snake on 4-key hardware

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -235,6 +235,8 @@ void game_start(uint16_t *fb)
 #if HW_KEY_COUNT == 4
     auxbtn_onOnePress(KEY3, on_turn_left);
     auxbtn_onOnePress(KEY4, on_turn_right);
+    btn_onOnePress(KEY1, NULL);
+    btn_onOnePress(KEY2, NULL);
 #else
     btn_onOnePress(KEY1, on_turn_left);
     btn_onOnePress(KEY2, on_turn_right);

--- a/src/game.c
+++ b/src/game.c
@@ -232,13 +232,12 @@ void game_start(uint16_t *fb)
     memset(game_fb, 0, LED_COLS * sizeof(uint16_t));
     init_game();
     draw_pixel(food.x, food.y, 1);
-
+#if HW_KEY_COUNT == 4
+    auxbtn_onOnePress(KEY3, on_turn_left);
+    auxbtn_onOnePress(KEY4, on_turn_right);
+#else
     btn_onOnePress(KEY1, on_turn_left);
     btn_onOnePress(KEY2, on_turn_right);
-    btn_onLongPress(KEY1, NULL);
-#if HW_KEY_COUNT == 4
-    auxbtn_onOnePress(KEY3, NULL);
-    auxbtn_onOnePress(KEY4, NULL);
 #endif
 
     tmos_start_task(game_taskid, GAME_TICK, MS_TO_TMOS(speed_ms));

--- a/src/main.c
+++ b/src/main.c
@@ -658,8 +658,15 @@ static void enter_clock_submenu()
 
     btn_onOnePress(KEY1, clock_submenu_nav);
     btn_onOnePress(KEY2, clock_submenu_nav);
+#if HW_KEY_COUNT == 4
+	btn_onLongPress(KEY1, NULL);
+    btn_onLongPress(KEY2, NULL);
+    auxbtn_onOnePress(KEY3, clock_submenu_select);
+    auxbtn_onOnePress(KEY4, return_to_menu);
+#else
     btn_onLongPress(KEY1, clock_submenu_select);
     btn_onLongPress(KEY2, return_to_menu);
+#endif
 
     disp_clock_submenu();
 }


### PR DESCRIPTION
Fixes #184

## Summary by Sourcery

Restore proper KEY3/KEY4 controls for the clock submenu and snake game on 4-key hardware while preserving 2-key behaviour.

Bug Fixes:
- Fix incorrect or disabled KEY3/KEY4 bindings in the snake game on 4-key hardware.
- Fix clock submenu navigation and selection bindings so KEY3/KEY4 work correctly on 4-key hardware.