### PR TITLE
leddrv: allow the REV3 T pin (B6) to be selected independently of J and K

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,5 +67,6 @@ jobs:
           git add ${{ env.USBC_2KEY_BUILD_DIR }}/badgemagic-*${{ env.BIN_TYPES }}
           git add ${{ env.MICROB_4KEY_BUILD_DIR }}/badgemagic-*${{ env.BIN_TYPES }}
           git add ${{ env.MICROB_2KEY_BUILD_DIR }}/badgemagic-*${{ env.BIN_TYPES }}
+          git add ${{ env.USBC_2KEY_TB6_BUILD_DIR }}/badgemagic-*${{ env.BIN_TYPES }}
           git commit -am "[Auto] Update firmware binaries from ${{ github.ref_name }} ($(date +%Y-%m-%d.%H:%M:%S))"
           git push --force origin bin

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,7 @@ env:
   USBC_2KEY_BUILD_DIR: usb-c-2key
   MICROB_4KEY_BUILD_DIR: micro-b-4key
   MICROB_2KEY_BUILD_DIR: micro-b-2key
+  USBC_2KEY_TB6_BUILD_DIR: usb-c-2key-tb6
   BIN_TYPES: '{.bin,.elf}'
 
 jobs:
@@ -41,6 +42,7 @@ jobs:
           BUILD_DIR=${{ env.USBC_2KEY_BUILD_DIR }} KEY_COUNT=2 make -j$(nproc)
           BUILD_DIR=${{ env.MICROB_4KEY_BUILD_DIR }} HARDWARE_REV1=1 KEY_COUNT=4 make -j$(nproc)
           BUILD_DIR=${{ env.MICROB_2KEY_BUILD_DIR }} HARDWARE_REV1=1 KEY_COUNT=2 make -j$(nproc)
+          BUILD_DIR=${{ env.USBC_2KEY_TB6_BUILD_DIR }} LED_PIN_T_B6=1 KEY_COUNT=2 make -j$(nproc)
 
       - uses: actions/upload-artifact@v4
         with:
@@ -50,6 +52,7 @@ jobs:
             ${{ env.USBC_2KEY_BUILD_DIR }}/badgemagic-*
             ${{ env.MICROB_4KEY_BUILD_DIR }}/badgemagic-*
             ${{ env.MICROB_2KEY_BUILD_DIR }}/badgemagic-*
+            ${{ env.USBC_2KEY_TB6_BUILD_DIR }}/badgemagic-*
 
       # Skip upload APK for pull requests & only allow binaries build from master
       - if: ${{ github.event_name != 'pull_request' && github.ref_name == 'master' }}

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,9 @@ endif
 ifeq ($(HARDWARE_REV3), 1)
 CFLAGS += -DHARDWARE_REV3=$(HARDWARE_REV3)
 endif
+ifeq ($(LED_PIN_T_B6), 1)
+CFLAGS += -DLED_PIN_T_B6=$(LED_PIN_T_B6)
+endif
 
 CFLAGS += -DHW_KEY_COUNT=$(KEY_COUNT)
 

--- a/README.md
+++ b/README.md
@@ -177,16 +177,55 @@ BUILD_DIR=custom-dir-if-needed make isp
 ```
 ## Building and flashing per hardware variant
 
-This firmware supports two independent build choices — you need to know both
-before building or downloading:
+This firmware supports three independent build choices — you need to know all
+of them before building or downloading:
 
 1. **Board revision** — controlled by `HARDWARE_REV1` / `HARDWARE_REV3`
    (see the [Build](#build) section above for what each targets).
 2. **Button count** — controlled by the new `KEY_COUNT` flag: `KEY_COUNT=4`
    (default) or `KEY_COUNT=2`.
+3. **T-pin mapping** — `LED_PIN_T_B6=1` for boards that need only the REV3 T pin;
+   see [Boards that need only the REV3 T pin](#boards-that-need-only-the-rev3-t-pin).
 
 If you're not sure which board revision or button count your badge has, see
 [CH582.md](./CH582.md) for identification help before flashing.
+
+### Boards that need only the REV3 T pin
+
+`HARDWARE_REV3` switches three LED matrix pins at once — J, K and T. At least one
+board needs **only** the T pin from REV3 (`B6`) while J and K stay on their
+default `B15`/`B14`. Neither stock variant drives such a panel correctly:
+
+* the default build leaves **columns 38-39 dark**;
+* `HARDWARE_REV3` fixes those two but takes out **columns 18-21** instead.
+
+For that board use `LED_PIN_T_B6=1`, which selects the T pin on its own:
+
+```sh
+BUILD_DIR=custom-dir LED_PIN_T_B6=1 KEY_COUNT=2 make
+```
+
+> [!NOTE]
+> Switching `LED_PIN_T_B6`, like switching `HARDWARE_REV*` or `KEY_COUNT`,
+> requires a clean build — otherwise a stale `src/leddrv.o` keeps the previous
+> T-pin mapping and the resulting firmware silently has the wrong pin. Pass the
+> same variables to `clean all`, or `make clean` will look in the default
+> `build/` directory and the rebuild will produce the default variant. This
+> is for re-building inside an existing `BUILD_DIR`; on a fresh checkout there
+> is nothing to clean yet, and `make clean` fails on the missing directory:
+>
+> ```sh
+> BUILD_DIR=custom-dir LED_PIN_T_B6=1 KEY_COUNT=2 make clean all
+> ```
+>
+> Building each variant into its own `BUILD_DIR` avoids this entirely.
+
+CI builds this variant as `usb-c-2key-tb6`, available both as a workflow
+artifact and in the [`bin`](https://github.com/fossasia/badgemagic-firmware/tree/bin) branch.
+
+**How to tell.** Light the whole panel and count the dark columns. Exactly one
+dead pair at 38-39 with everything else lit means the T pin, and this flag.
+If columns 18-21 go dark under `HARDWARE_REV3`, that board is not REV3.
 
 ### Building from source
 

--- a/src/leddrv.c
+++ b/src/leddrv.c
@@ -119,7 +119,7 @@ static const pindesc_t led_pins[LED_PINCOUNT] = {
 	PINDESC(B, 4),  // Q
 	PINDESC(B, 2),  // R
 	PINDESC(B, 1),  // S
-#ifdef HARDWARE_REV3
+#if defined(HARDWARE_REV3) || defined(LED_PIN_T_B6)
 	PINDESC(B, 6), // T
 #else
 	PINDESC(B, 23), // T


### PR DESCRIPTION
## Problem

`HARDWARE_REV3` switches three LED matrix pins at once — J, K and T. There is at least one board in the wild that needs **only** the T pin from REV3 while J and K stay on the default mapping. Neither existing variant drives such a panel correctly:

- default build → columns **38 and 39** never light
- `HARDWARE_REV3` → those two work, but columns **18–21** would go dark instead

## Hardware and evidence

CH582M, 11×44, USB-C, 2 keys, OEM BLE name `LSLED`. Flashed the `usb-c-2key` CI artifact from `master` @ `b2137f08`.

Symptom: two dead columns, in both `stream_bitmap` output and ordinary `wang` image uploads — so the transport was not involved.

Localised by lighting **two columns at a time** and asking which ones lit, plus a marker pattern of five 4-column blocks starting at columns 0, 9, 18, 27 and 36:

| Columns | Expected | Observed |
|---|---|---|
| 0–3, 9–12, 18–21, 27–30 | lit | lit |
| 36–39 | lit | **only 36 and 37** |
| 42–43 (lit on their own) | — | lit |

So exactly one double-column is dead: **19**, which `led_write2dcol(i >> 2, fb[i >> 1], fb[(i >> 1) + 1])` maps to columns 38–39, driven by `led_pins[19]` — the T pin. Columns 18–21 (pins J and K) work with the default mapping, and 42–43 work too.

## Change

```diff
-#ifdef HARDWARE_REV3
+#if defined(HARDWARE_REV3) || defined(LED_PIN_T_B6)
 	PINDESC(B, 6), // T
 #else
 	PINDESC(B, 23), // T
 #endif
```

plus the `LED_PIN_T_B6` passthrough in the `Makefile` and a CI build of the resulting variant (`usb-c-2key-tb6`).

Existing builds are untouched: without the new flag every variant compiles exactly as before.

## Verification

Built the new variant through CI, flashed it, re-ran the same block pattern: all five blocks now render in full, and the previously working columns stayed working.

Given issue #59, where a mismatched variant cost someone their badge, it seems worth making these pins selectable rather than bundled — and worth documenting that a board with this combination exists.

Happy to rename the flag or fold it into a `HARDWARE_REV2B`-style variant if you prefer a different shape.

Client and diagnostics used: https://github.com/NickoScope/LED-Badge-CH582M

## Summary by Sourcery

Support boards that require the REV3 T-pin mapping independently of the J and K mappings.

New Features:
- Add an independent build option for boards that use the REV3 T-pin mapping without changing the J and K mappings.
- Provide a CI-built firmware variant for the USB-C two-key board using the independent T-pin mapping.

Bug Fixes:
- Fix LED matrix support for boards where columns 38–39 require the REV3 T pin while columns 18–21 retain the default mapping.

Enhancements:
- Document the T-pin variant, board identification guidance, and clean-build requirements for selecting hardware mappings.

CI:
- Build, publish, and archive the new USB-C two-key T-pin variant in CI.

Documentation:
- Document the independent T-pin mapping, its intended hardware, usage, and diagnostics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added firmware support for the USB-C 2-key TB6 hardware variant.
  * Added downloadable build artifacts for this variant.
  * Added guidance for identifying compatible boards and building the appropriate firmware.

* **Bug Fixes**
  * Corrected LED T pin selection for USB-C 2-key TB6 hardware.

* **Documentation**
  * Documented the required clean-build step when switching LED pin mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->