### PR TITLE
ble: raise the MTU ceiling to 128 so a full-width stream_bitmap frame fits one ATT write (4.7 → 30 fps, no more dropped links)

### DIFF
--- a/BadgeBLE.md
+++ b/BadgeBLE.md
@@ -81,7 +81,7 @@ The "mode" bytes are a combination of two 4 bit values. The high nibble describe
     A Write Command (without response) carries no ATT acknowledgement and
     therefore no backpressure: a client using it must pace its own writes,
     otherwise it floods the host queue. Protocol errors on that path are
-    reported only through the 0xF056 notification, as `0xff`.
+    reported only through the 0xF056 notification, as `0xf0` (see below).
 - Characteristic: 0xF056 (128-bit equivalent:
   0000f056-0000-1000-8000-00805f9b34fb)
   - Notify property: to return error codes
@@ -115,6 +115,18 @@ Supported functions/commands:
 
 The client app should enable notifications for the characteristic to receive the
 returned error code (e.g., by using setCharacteristicNotification() on Android).
+
+Every packet is answered with one status byte on 0xF056:
+
+- `0x00`: the command succeeded.
+- `0xff`..`0xfc`: the command's handler rejected it; the meaning is listed
+  per command below (`0xff` is the common "parameters out of range").
+- `0xf0`: the packet never reached a handler -- it was empty, the command
+  code is unknown, or the command has no implementation. Over a Write
+  Request the same cases also fail the ATT write; over a Write Command this
+  byte is the only feedback.
+- Any other non-zero value is handler specific: `save_cfg` forwards the
+  flash driver's own status (documented there as `0x01`).
 
 ##### power_setting
 
@@ -239,8 +251,10 @@ Parameters:
 
 Returns:
 
-- Parameters out of range: `0xff`.
-- `speed_ms` or `brightness_level` is out of allowed range: `0x02`.
+- Unknown sub-command (first byte above `0x01`): `0xff`.
+- `speed_ms` below the minimum: `0xff`.
+- Empty packet, a sub-command without its full parameter, or
+  `brightness_level` above 3: `0xfe`.
 - Success: `0x00`.
 
 #### Example

--- a/BadgeBLE.md
+++ b/BadgeBLE.md
@@ -77,7 +77,11 @@ The "mode" bytes are a combination of two 4 bit values. The high nibble describe
   0000f055-0000-1000-8000-00805f9b34fb)
 - Characteristic: 0xF057 (128-bit equivalent:
   0000f057-0000-1000-8000-00805f9b34fb)
-  - Write property: to receive controls and configs
+  - Write and Write Without Response properties: to receive controls and configs.
+    A Write Command (without response) carries no ATT acknowledgement and
+    therefore no backpressure: a client using it must pace its own writes,
+    otherwise it floods the host queue. Protocol errors on that path are
+    reported only through the 0xF056 notification, as `0xff`.
 - Characteristic: 0xF056 (128-bit equivalent:
   0000f056-0000-1000-8000-00805f9b34fb)
   - Notify property: to return error codes
@@ -85,9 +89,16 @@ The "mode" bytes are a combination of two 4 bit values. The high nibble describe
 
 #### Protocol
 
-The next-gen characteristic accepts messages of varying lengths (0 to 512
+The next-gen characteristic accepts messages of varying lengths (1 to 512
 bytes). The first byte represents the function/command code, while the remaining
 bytes contain parameters for the corresponding function/command.
+
+The firmware accepts an MTU exchange of up to 128; a client that does not
+request it stays at the default 23. At 128 a single Write Request or Write
+Command carries at most `MTU - 3 = 125` bytes -- enough for a full-width
+`stream_bitmap` frame (1 + 44 × 2 = 89 bytes) in one packet. Longer messages
+still work over Write Request as a Write Long (prepared writes), but not over
+Write Command, which has no long form.
 
 ![next-gen message format](/assets/ng-protocol.svg)
 

--- a/src/ble/profile/ng.c
+++ b/src/ble/profile/ng.c
@@ -15,7 +15,7 @@ static uint8_t TxCharVal[256];
 static uint16_t TxLen;
 
 static const uint16_t RxCharUUID = 0xF057;
-static uint8_t RxCharProps = GATT_PROP_WRITE;
+static uint8_t RxCharProps = GATT_PROP_WRITE | GATT_PROP_WRITE_NO_RSP;
 #define RxCharVal TxCharVal
 static gattCharCfg_t TxCCCD[1];
 

--- a/src/ble/profile/ng.c
+++ b/src/ble/profile/ng.c
@@ -73,6 +73,13 @@ static bStatus_t read_handler(uint16_t connHandle, gattAttribute_t *pAttr,
 	}
 
 	if (uuid == TxCharUUID) {
+		/* TxLen is the amount of valid data in TxCharVal. A Read Blob with an
+		 * offset past it would make TxLen-offset wrap in uint16_t and the copy
+		 * below would hand out up to maxLen bytes of whatever follows the
+		 * buffer -- a larger MTU makes that window larger, not smaller. */
+		if (offset > TxLen) {
+			return ATT_ERR_INVALID_OFFSET;
+		}
 		*pLen = MIN(TxLen-offset, maxLen);
 		tmos_memcpy(pValue, &pAttr->pValue[offset], *pLen);
 		return SUCCESS;

--- a/src/ble/profile/ng.c
+++ b/src/ble/profile/ng.c
@@ -73,14 +73,18 @@ static bStatus_t read_handler(uint16_t connHandle, gattAttribute_t *pAttr,
 	}
 
 	if (uuid == TxCharUUID) {
-		/* TxLen is the amount of valid data in TxCharVal. A Read Blob with an
-		 * offset past it would make TxLen-offset wrap in uint16_t and the copy
-		 * below would hand out up to maxLen bytes of whatever follows the
-		 * buffer -- a larger MTU makes that window larger, not smaller. */
-		if (offset > TxLen) {
+		/* TxLen is the amount of valid data in TxCharVal. The characteristic
+		 * is readable, but nothing sets TxLen yet, so a read returns zero
+		 * bytes. The guard must not trust it either way: bound it by the
+		 * buffer, and refuse a Read Blob offset past it -- otherwise
+		 * TxLen-offset wraps in uint16_t and the copy below hands out up to
+		 * maxLen bytes of whatever follows the buffer. A larger MTU makes
+		 * that window larger. */
+		uint16_t valid = MIN(TxLen, sizeof(TxCharVal));
+		if (offset > valid) {
 			return ATT_ERR_INVALID_OFFSET;
 		}
-		*pLen = MIN(TxLen-offset, maxLen);
+		*pLen = MIN(valid - offset, maxLen);
 		tmos_memcpy(pValue, &pAttr->pValue[offset], *pLen);
 		return SUCCESS;
 	}

--- a/src/ble/setup.c
+++ b/src/ble/setup.c
@@ -70,7 +70,7 @@ void tmos_clockInit(void)
 	TMOS_TimerInit(0);
 }
 
-void ble_hardwareInit(void)
+int ble_hardwareInit(void)
 {
 	bleConfig_t cfg;
 	memset(&cfg, 0, sizeof(bleConfig_t));
@@ -95,9 +95,11 @@ void ble_hardwareInit(void)
 	if (st != SUCCESS) {
 		/* ERR_MEM_ALLOCATE_SIZE (0x02) means MEMLen is too small for
 		 * BufNumber x BufMaxLen -- the one failure a larger BLE_BUFF_LEN can
-		 * introduce. Logged in DEBUG builds (PRINT is empty in release) so that
-		 * it does not surface only later as flaky ATT or a dropped link while
-		 * the badge still advertises. */
+		 * introduce. PRINT is empty in release builds, so the caller has to
+		 * act on the status. On a chip whose factory MAC reads back, every
+		 * remaining failure is a compile-time configuration error. */
 		PRINT("ble: BLE_LibInit failed: 0x%02x\n", st);
+		return st;
 	}
+	return 0;
 }

--- a/src/ble/setup.c
+++ b/src/ble/setup.c
@@ -4,11 +4,16 @@
 #include "setup.h"
 #include "CH58xBLE_LIB.h"
 #include "CH58x_common.h"
+#include "../debug.h"
 
 #ifndef BLE_BUFF_LEN
 // MTU = 128 but clients should request new MTU, otherwise default will be 23.
 // 64 was too small for stream_bitmap: a full 44-column frame is 89 bytes and
 // did not fit one ATT write, so every frame became a Write Long.
+// Note for clients: F057 also accepts Write Command (GATT_PROP_WRITE_NO_RSP).
+// That path has no ATT response and therefore no backpressure -- a client that
+// writes as fast as its loop runs will flood the host queue, so it must pace
+// itself. See BadgeBLE.md.
 #define BLE_BUFF_LEN (128 + 4)
 #endif
 
@@ -32,6 +37,11 @@
 #ifndef BLE_BUFF_NUM
 // The BLE lib automatically stack up Write Long messages in Write handler.
 // A connection will be disconnected if this number is some how not enough.
+// 512 / 23 was sized to reassemble a 512-byte Write Long at the default
+// MTU of 23. With BLE_BUFF_LEN raised to 128+4 the same 22 buffers now hold
+// ~2.7 KB of Write Long payload, so the count is generous rather than tight;
+// it is left unchanged on purpose so the memory budget only moves in one
+// direction and any shortfall shows up in BLE_LibInit() instead of at runtime.
 #define BLE_BUFF_NUM        (512 / 23)
 #endif
 
@@ -81,5 +91,13 @@ void ble_hardwareInit(void)
 	GetMACAddress(m);
 	memcpy(cfg.MacAddr, m, 6);
 
-	BLE_LibInit(&cfg);
+	bStatus_t st = BLE_LibInit(&cfg);
+	if (st != SUCCESS) {
+		/* ERR_MEM_ALLOCATE_SIZE (0x02) means MEMLen is too small for
+		 * BufNumber x BufMaxLen -- the one failure a larger BLE_BUFF_LEN can
+		 * introduce. Logged in DEBUG builds (PRINT is empty in release) so that
+		 * it does not surface only later as flaky ATT or a dropped link while
+		 * the badge still advertises. */
+		PRINT("ble: BLE_LibInit failed: 0x%02x\n", st);
+	}
 }

--- a/src/ble/setup.c
+++ b/src/ble/setup.c
@@ -6,8 +6,10 @@
 #include "CH58x_common.h"
 
 #ifndef BLE_BUFF_LEN
-// MTU = 64 but clients should request new MTU, otherwise default will be 23
-#define BLE_BUFF_LEN (64 + 4)
+// MTU = 128 but clients should request new MTU, otherwise default will be 23.
+// 64 was too small for stream_bitmap: a full 44-column frame is 89 bytes and
+// did not fit one ATT write, so every frame became a Write Long.
+#define BLE_BUFF_LEN (128 + 4)
 #endif
 
 #ifndef BLE_TX_NUM_EVENT

--- a/src/ble/setup.h
+++ b/src/ble/setup.h
@@ -2,7 +2,7 @@
 #define __BLE_SETUP_H__
 
 void tmos_clockInit(void);
-void ble_hardwareInit(void);
+int ble_hardwareInit(void);   /* 0 on success, else the BLE_LibInit status */
 void peripheral_init(void);
 
 void ble_enable_advertise();

--- a/src/main.c
+++ b/src/main.c
@@ -254,9 +254,40 @@ static uint16_t common_tasks(tmosTaskID task_id, uint16_t events)
 	return 0;
 }
 
+/* BLE_LibInit() also brings up TMOS, and every task below -- buttons,
+ * animation, clock, games -- runs on TMOS. If it fails there is nothing to
+ * continue with, and PRINT is empty in release builds, so the failure would
+ * otherwise look like a badge that boots and then does nothing. The display
+ * refresh is interrupt driven and still works, so show it: a checkerboard
+ * that no normal mode ever draws, with the first <status> columns lit solid
+ * to give the BLE_LibInit code, then stop -- WCH's own HAL/MCU.c does the
+ * same. On a chip whose factory MAC reads back the cause is the compile-time
+ * BLE configuration (the ERR_LIB_INIT codes in CH58xBLE_LIB.h). From here
+ * only the hardware ISP entry works; the software one is a TMOS task that
+ * never starts. */
+static void ble_init_failed(int status) __attribute__((noreturn));
+static void ble_init_failed(int status)
+{
+	/* The ERR_LIB_INIT codes are 1..7; anything larger is capped so that
+	 * at least one checkerboard column stays and the pattern is still
+	 * recognisable. */
+	if (status > LED_COLS - 1) {
+		status = LED_COLS - 1;
+	}
+	for (int i = 0; i < LED_COLS; i++) {
+		fb[i] = (i < status) ? 0x07FF : ((i & 1) ? 0x02AA : 0x0555);
+	}
+	while (1) {
+		DelayMs(1000);
+	}
+}
+
 void ble_setup()
 {
-	ble_hardwareInit();
+	int st = ble_hardwareInit();
+	if (st != 0) {
+		ble_init_failed(st);
+	}
 	tmos_clockInit();
 
 	peripheral_init();

--- a/src/ngctrl.c
+++ b/src/ngctrl.c
@@ -194,13 +194,30 @@ const uint8_t (*cmd_lut[])(uint8_t *val, uint16_t len) = {
 
 #define CMD_LUT_LEN (sizeof(cmd_lut) / sizeof(cmd_lut[0]))
 
+/* Reported when the packet never reaches a handler at all: empty, an unknown
+ * command code, or a command with no implementation. 0xFF is what a handler
+ * returns for the common "parameters out of range" case (`return -1` in a
+ * uint8_t); handlers also use -2..-4 for more specific failures, so this value
+ * marks the coarsest class of failure rather than a single shared convention. */
+#define NG_ERR_INVALID  0xFF
+
 uint8_t ng_parse(uint8_t *val, uint16_t len)
 {
-	if (len < 1) return bleInvalidRange;
+	uint8_t err = NG_ERR_INVALID;
+
+	/* The characteristic accepts Write Command as well as Write Request, and a
+	 * Write Command carries no ATT response. The notification is then the only
+	 * channel a client has, so protocol errors must be reported there too --
+	 * otherwise an unacknowledged write of a malformed packet is silent. */
+	if (len < 1) {
+		ng_notify(&err, 1);
+		return bleInvalidRange;
+	}
 	uint8_t cmd = val[0];
 	PRINT("LUT_LEN: %02x \n", CMD_LUT_LEN);
 	if (cmd >= CMD_LUT_LEN) {
 		PRINT("invalid command!\n");
+		ng_notify(&err, 1);
 		return bleInvalidRange;
 	}
 
@@ -210,6 +227,8 @@ uint8_t ng_parse(uint8_t *val, uint16_t len)
 		ng_notify(&ret, 1); // response to the client app
 	} else {
 		PRINT("function is not defined!\n");
+		ng_notify(&err, 1);
+		return bleInvalidRange;
 	}
 	return SUCCESS;
 }

--- a/src/ngctrl.c
+++ b/src/ngctrl.c
@@ -153,6 +153,7 @@ static uint8_t cfg_led_brightness(uint8_t *val, uint16_t len)
 	PRINT(__func__);
 	PRINT("\n");
 
+	if (len < 1) return -2;
 	uint8_t lvl = val[0];
 	if (lvl >= BRIGHTNESS_LEVELS)
 		return -2;
@@ -195,11 +196,12 @@ const uint8_t (*cmd_lut[])(uint8_t *val, uint16_t len) = {
 #define CMD_LUT_LEN (sizeof(cmd_lut) / sizeof(cmd_lut[0]))
 
 /* Reported when the packet never reaches a handler at all: empty, an unknown
- * command code, or a command with no implementation. 0xFF is what a handler
- * returns for the common "parameters out of range" case (`return -1` in a
- * uint8_t); handlers also use -2..-4 for more specific failures, so this value
- * marks the coarsest class of failure rather than a single shared convention. */
-#define NG_ERR_INVALID  0xFF
+ * command code, or a command with no implementation. Handlers report their
+ * own failures as -1..-4 (0xFF..0xFC in the uint8_t status byte), so this
+ * value stays outside that range: over a Write Command the notification is
+ * the only feedback, and a client must be able to tell "rejected before any
+ * handler" from "a handler rejected the parameters". */
+#define NG_ERR_INVALID  0xF0
 
 uint8_t ng_parse(uint8_t *val, uint16_t len)
 {


### PR DESCRIPTION
Fixes #192.

## Problem

A full-width `stream_bitmap` frame is `1 + LED_COLS * 2 = 89` bytes. `BLE_BUFF_LEN (64 + 4)` caps the MTU at 64, so an ATT write carries 61 bytes and every frame has to go as a Write Long: two `ATT_PREPARE_WRITE_REQ` plus one `ATT_EXECUTE_WRITE_REQ`, each awaiting its response — three round trips per frame.

That costs throughput, and it also drops the link. The comment above `BLE_BUFF_NUM` in the same file already predicts it:

```c
// The BLE lib automatically stack up Write Long messages in Write handler.
// A connection will be disconnected if this number is some how not enough.
#define BLE_BUFF_NUM        (512 / 23)
```

Continuous full-width streaming is precisely that workload; the pool of 22 buffers runs dry.

## Measured on hardware

CH582M, 11×44, USB-C, 2 keys, `master` @ `b2137f08`. Host: macOS, `bleak`. Same client, same seven scenes, ~45 s per run.

| Client mode | fps | Panel | Frame tearing | Link drops |
|---|---|---|---|---|
| 30-column frames (fit one ATT write) | 14.9 | right quarter static | no | no |
| 30-column + full frame every 6th | 9.3 | whole | **yes** | no |
| full-width, before this patch | **4.7** | whole | no | **every ~30 s** |
| **full-width, after this patch** | **30.0** | **whole** | **no** | **no** |

30 fps is a cap the client sets, not a hardware limit; the headroom was not probed. 1440 frames in 48 s with zero drops.

## Change

```diff
-#define BLE_BUFF_LEN (64 + 4)
+#define BLE_BUFF_LEN (128 + 4)
```

```diff
-static uint8_t RxCharProps = GATT_PROP_WRITE;
+static uint8_t RxCharProps = GATT_PROP_WRITE | GATT_PROP_WRITE_NO_RSP;
```

The MTU bump is the necessary part. `GATT_PROP_WRITE_NO_RSP` on its own would **not** help — `Write Command` is limited to `ATT_MTU - 3` and has no long form, so at MTU 64 an 89-byte frame still could not be sent unacknowledged. It becomes useful only once the frame fits a single packet, which is why both changes ship together.

## Memory

`BLE_BUFF_LEN` 68 → 132 with `BLE_BUFF_NUM` unchanged at 22 takes buffer memory from ~1.5 KB to ~2.9 KB out of the 6 KB `BLE_MEMHEAP_SIZE`. The stack initialised and ran normally on this device across many runs. If that is too tight for other configurations, `BLE_BUFF_NUM` can be lowered in the same breath, since long writes stop being the normal path for streaming clients.

## Note for client authors

Unacknowledged writes remove the backpressure the response used to provide. A client that keeps writing as fast as its loop runs will flood the host queue — the first run here reported ~86 000 "frames" per second and then stalled for 22 s. Clients need to pace themselves; worth a line in `BadgeBLE.md` if this lands.

Client and measurement harness: https://github.com/NickoScope/LED-Badge-CH582M (`stream_demo.py`)

## Summary by Sourcery

Raise BLE packet capacity and add write-without-response support so full-width bitmap streaming avoids long-write overhead while improving protocol error reporting and initialization safety.

New Features:
- Support larger BLE MTU negotiation and unacknowledged writes so full-width bitmap frames can fit in a single ATT packet.
- Expose BLE initialization failures through a visible device error state.

Bug Fixes:
- Prevent out-of-bounds characteristic reads when read offsets exceed the valid response buffer.
- Report malformed, unknown, and unimplemented commands through notifications, including for writes without response.
- Reject empty brightness configuration commands instead of accessing missing parameters.

Enhancements:
- Document BLE write pacing requirements, MTU behavior, packet status responses, and updated protocol validation semantics.

Documentation:
- Update the BLE protocol documentation for write-without-response behavior, larger MTUs, status notifications, and command error handling.

Chores:
- Increase BLE buffer capacity to support larger packets while retaining the existing buffer count and initialization safeguards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Added support for BLE write-without-response operations.
  - Increased the BLE data buffer to support larger messages and stream frames.
  - BLE initialization failures now display a checkerboard error indicator and halt setup.

- **Bug Fixes**
  - Invalid read offsets and empty packets are rejected safely.
  - Protocol error responses now distinguish pre-handler rejection from handler-level failures.

- **Documentation**
  - Updated BLE protocol, MTU, write behavior, message lengths, and error-code details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->