### PR TITLE
ble: free the notification buffer only when GATT_Notification fails

### DIFF
--- a/src/ble/profile/ng.c
+++ b/src/ble/profile/ng.c
@@ -155,7 +155,7 @@ bStatus_t ng_notify(uint8_t *val, uint8_t len)
 		 * WCH's own example frees only on failure: EVT/EXAM/BLE/Peripheral/
 		 * APP/peripheral.c, peripheralChar4Notify(). */
 		GATT_bm_free((gattMsg_t *)&noti, ATT_HANDLE_VALUE_NOTI);
-		PRINT("ble: noti sending failed\n");
+		PRINT("ble: noti sending failed: 0x%02x\n", ret);
 		return ret;
 	}
 

--- a/src/ble/profile/ng.c
+++ b/src/ble/profile/ng.c
@@ -149,8 +149,12 @@ bStatus_t ng_notify(uint8_t *val, uint8_t len)
 	tmos_memcpy(noti.pValue, val, len);
 
 	bStatus_t ret = GATT_Notification(TxCCCD->connHandle, &noti, FALSE);
-	GATT_bm_free((gattMsg_t *)&noti, ATT_HANDLE_VALUE_NOTI);
 	if (ret != SUCCESS) {
+		/* On SUCCESS the stack owns the buffer and frees it; freeing it
+		 * here as well would release it twice.
+		 * WCH's own example frees only on failure: EVT/EXAM/BLE/Peripheral/
+		 * APP/peripheral.c, peripheralChar4Notify(). */
+		GATT_bm_free((gattMsg_t *)&noti, ATT_HANDLE_VALUE_NOTI);
 		PRINT("ble: noti sending failed\n");
 		return ret;
 	}


### PR DESCRIPTION
`ng_notify()` allocates the notification value with `GATT_bm_alloc()`, hands it to `GATT_Notification()` and then calls `GATT_bm_free()` unconditionally. On `SUCCESS` the stack takes ownership of the buffer and frees it, so the unconditional free releases the same block twice.

**Source.** WCH's own Peripheral example frees only on failure — `EVT/EXAM/BLE/Peripheral/APP/peripheral.c`, `peripheralChar4Notify()` (openwch/ch583 @ bd508ad7):

```c
if(simpleProfile_Notify(peripheralConnList.connHandle, &noti) != SUCCESS)
{
    GATT_bm_free((gattMsg_t *)&noti, ATT_HANDLE_VALUE_NOTI);
}
```

and `simpleProfile_Notify()` in `EVT/EXAM/BLE/Peripheral/Profile/gattprofile.c` returns `GATT_Notification(connHandle, pNoti, FALSE)` directly — the same call `ng_notify()` makes. The library header in this repo (`CH5xx_ble_firmware_library/BLE/CH58xBLE_LIB.h`) documents ownership for the neighbouring GATT client calls ("pointer will be freed when the sub-procedure is complete", lines 3498/3543/3683) and says nothing for `GATT_Notification` at 2989; the library itself is a binary, so the vendor example is the best available statement of the contract.

**What this PR does.** Moves `GATT_bm_free()` under `if (ret != SUCCESS)`. One file, six lines. Every path after the allocation is covered: failure frees and returns, success hands the buffer to the stack; the early returns before the allocation have nothing to free.

**Caveats.** Not observed on hardware: the call is gated by the CCCD, and the clients used for #194 had not subscribed to F056, so neither the double free nor a leak would have shown. This is derived from the vendor example, not from a crash. If a maintainer has the stack's behaviour on `SUCCESS` from WCH directly, that beats this inference. I can run a subscribe-and-hammer test on the CH582M badge if that helps.

Found while re-checking `ng_notify()` for #194; kept separate because it is pre-existing and independent of the MTU change. Different hunks, no conflict with #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix notification buffer ownership handling so successful GATT notifications can be freed by the stack without being released twice.

Bug Fixes:
- Prevent double-freeing notification buffers by releasing them only when GATT notification delivery fails.
- Include the GATT failure status in notification-send diagnostics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed notification handling to prevent potential memory errors when sending succeeds.
  - Notification payloads are now released correctly when delivery fails, with the failure reported appropriately.
  - Improved notification reliability by ensuring successful deliveries complete without triggering duplicate cleanup.
  - Delivery failures now return the appropriate error status, making unsuccessful notification attempts easier to detect and handle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->